### PR TITLE
Update colors package

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@arangodb": false
   },
   "devDependencies": {
-    "@types/colors": "^1.1.3",
     "@types/cors": "^2.8.1",
     "@types/graphql": "^0.12.4",
     "@types/graphql-type-json": "^0.1.2",
@@ -55,7 +54,7 @@
   "dependencies": {
     "ajv": "^6.0.1",
     "arangojs": "~5.7.1",
-    "colors": "^1.1.2",
+    "colors": "^1.2.1",
     "graphql-tag": "^2.5.0",
     "graphql-transformer": "^0.1.4",
     "graphql-type-json": "^0.1.4",

--- a/spec/performance/support/runner.ts
+++ b/spec/performance/support/runner.ts
@@ -1,6 +1,6 @@
 import { benchmark, BenchmarkFactories, time } from './async-bench';
+import colors = require('colors');
 
-const colors = require('colors');
 colors.enabled = true;
 
 const SHOW_CYCLE_INFO = false;


### PR DESCRIPTION
The npm package now contains its own types, so we don't need the types. Removed the types because they may have caused bugs in the travis build.