### PR TITLE
Whitelist graphql validation rules

### DIFF
--- a/src/schema/preparation/source-validation-modules/graphql-rules.ts
+++ b/src/schema/preparation/source-validation-modules/graphql-rules.ts
@@ -1,12 +1,30 @@
 import { SourceValidator } from '../ast-validator';
 import { ProjectSource, SourceType } from '../../../project/source';
 import { ValidationMessage } from '../validation-message';
-import { buildASTSchema, DocumentNode, GraphQLError, Location, parse, Source, specifiedRules, validate } from 'graphql';
+import { buildASTSchema, DocumentNode, GraphQLError, Location, parse, Source, specifiedRules, validate, KnownDirectivesRule, KnownTypeNamesRule, UniqueDirectivesPerLocationRule,
+    KnownArgumentNamesRule,
+    VariablesInAllowedPositionRule,
+    UniqueInputFieldNamesRule,
+    UniqueArgumentNamesRule,
+    ProvidedNonNullArgumentsRule } from 'graphql';
 import { CORE_SCALARS, DIRECTIVES } from '../../graphql-base';
 import gql from 'graphql-tag';
 
-// ExecutableDefinitions does not allow the SDL definitions
-const rules = specifiedRules.filter(rule => rule.name != 'ExecutableDefinitions');
+// Only include rules that are relevant for schema files
+// This is not only for efficiency - specifiedRules also includes ExecutableOperationRule which disallows all type
+// definitions, but it is not exported so we can't exclude it.
+const rules = [
+    KnownTypeNamesRule,
+    KnownDirectivesRule,
+    UniqueDirectivesPerLocationRule,
+    KnownArgumentNamesRule,
+    UniqueArgumentNamesRule,
+    //ValuesOfCorrectTypeRule, // this and VariablesDefaultValueAllowedRule is not in the types of graphql 0.12 (and the types of 0.13 are incompatible due to readonly stuff)
+    ProvidedNonNullArgumentsRule,
+    //VariablesDefaultValueAllowedRule,
+    VariablesInAllowedPositionRule,
+    UniqueInputFieldNamesRule
+];
 
 export class GraphQLRulesValidator implements SourceValidator {
     validate(source: ProjectSource): ValidationMessage[] {


### PR DESCRIPTION
Blacklisting with .name comparision causes problems when mangling
names in a minification step