### PR TITLE
Resolve mutation fields sequentially

### DIFF
--- a/spec/regression/logistics/tests/field-permission-granted.result.json
+++ b/spec/regression/logistics/tests/field-permission-granted.result.json
@@ -87,7 +87,7 @@
   "update": {
     "data": {
       "updateDelivery": {
-        "deliveryNumber": "2"
+        "deliveryNumber": "1000173"
       },
       "updateForwarder": {
         "name": "DPD"

--- a/spec/regression/namespaced_logistics/tests/field-permission-granted.result.json
+++ b/spec/regression/namespaced_logistics/tests/field-permission-granted.result.json
@@ -115,7 +115,7 @@
       "logistics": {
         "delivery": {
           "updateDelivery": {
-            "deliveryNumber": "2"
+            "deliveryNumber": "1000173"
           },
           "update2": {
             "deliveryNumber": "2"

--- a/spec/regression/papers/tests/serial-mutations.graphql
+++ b/spec/regression/papers/tests/serial-mutations.graphql
@@ -1,0 +1,9 @@
+mutation {
+    a: updatePaper(input: { id: "@{ids/Paper/1}", title: "Test 1" }) {
+        title
+    }
+
+    b: updatePaper(input: { id: "@{ids/Paper/2}", title: "Test 2" }) {
+        title
+    }
+}

--- a/spec/regression/papers/tests/serial-mutations.result.json
+++ b/spec/regression/papers/tests/serial-mutations.result.json
@@ -1,0 +1,10 @@
+{
+  "data": {
+    "a": {
+      "title": "Test 1"
+    },
+    "b": {
+      "title": "Test 2"
+    }
+  }
+}

--- a/src/schema-generation/mutation-type-generator.ts
+++ b/src/schema-generation/mutation-type-generator.ts
@@ -75,6 +75,7 @@ export class MutationTypeGenerator {
                     type: new GraphQLNonNull(inputType.getInputType())
                 }
             },
+            isSerial: true,
             resolve: (_, args) => this.generateCreateQueryNode(rootEntityType, args[MUTATION_INPUT_ARG], inputType)
         };
     }
@@ -101,6 +102,7 @@ export class MutationTypeGenerator {
                     type: new GraphQLNonNull(inputType.getInputType())
                 }
             },
+            isSerial: true,
             resolve: (_, args) => this.generateUpdateQueryNode(rootEntityType, args[MUTATION_INPUT_ARG], inputType)
         };
     }
@@ -175,6 +177,7 @@ export class MutationTypeGenerator {
                     type: new GraphQLNonNull(inputType.getInputType())
                 }
             },
+            isSerial: true,
             resolve: (_, args, info) => this.generateUpdateAllQueryNode(rootEntityType, fieldWithListArgs.resolve(_, args, info), inputType, args[MUTATION_INPUT_ARG])
         };
     }
@@ -226,6 +229,7 @@ export class MutationTypeGenerator {
             name: getDeleteEntityFieldName(rootEntityType.name),
             type: this.outputTypeGenerator.generate(rootEntityType),
             args: getArgumentsForUniqueFields(rootEntityType),
+            isSerial: true,
             resolve: (source, args) => this.generateDeleteQueryNode(rootEntityType, args)
         };
     }
@@ -260,6 +264,7 @@ export class MutationTypeGenerator {
 
         return {
             ...fieldWithListArgs,
+            isSerial: true,
             resolve: (source, args, info) => this.generateDeleteAllQueryNode(rootEntityType, fieldWithListArgs.resolve(source, args, info))
         };
     }

--- a/src/schema-generation/query-node-object-type/definition.ts
+++ b/src/schema-generation/query-node-object-type/definition.ts
@@ -15,6 +15,11 @@ export interface QueryNodeField {
     type: QueryNodeOutputType
     args?: GraphQLFieldConfigArgumentMap
     resolve: (sourceNode: QueryNode, args: { [name: string]: any }, info: QueryNodeResolveInfo) => QueryNode
+
+    /**
+     * Indicates whether this field should be resolved in the user-specified sequence among other serial fields
+     */
+    isSerial?: boolean
 }
 
 export interface QueryNodeObjectType {


### PR DESCRIPTION
According to the GraphQL specification, mutation fields should be
evaluated serially (not in parallel). The most visible effect is that
the selection of field A does not see the changes done by field B if it
is placed before it. Previously, this was not the case and could lead to
confusion.