### PR TITLE
Change id-sort-clause adding behavior

### DIFF
--- a/spec/regression/papers/tests/pagination.graphql
+++ b/spec/regression/papers/tests/pagination.graphql
@@ -31,4 +31,8 @@ query {
     noPagesLeft: allPapers(first: 2, after: "{\"id\":\"@{ids/Paper/5}\",\"key\":\"Scal\"}", filter: {isPublished: true}, orderBy: key_ASC) {
         key
     }
+
+    noPaginationButCursor: allPapers(filter: { id: "@{ids/Paper/1}" }) {
+        _cursor
+    }
 }

--- a/spec/regression/papers/tests/pagination.result.json
+++ b/spec/regression/papers/tests/pagination.result.json
@@ -29,6 +29,11 @@
         "empty": []
       }
     ],
-    "noPagesLeft": []
+    "noPagesLeft": [],
+    "noPaginationButCursor": [
+      {
+        "_cursor": "{\"id\":\"@{ids/Paper/1}\"}"
+      }
+    ]
   }
 }

--- a/src/schema-generation/output-type-generator.ts
+++ b/src/schema-generation/output-type-generator.ts
@@ -1,14 +1,14 @@
 import { GraphQLString } from 'graphql';
 import { sortBy } from 'lodash';
 import memorize from 'memorize-decorator';
-import { getMetaFieldName } from '../schema/names';
 import { FieldRequest } from '../graphql/query-distiller';
 import { isListType } from '../graphql/schema-utils';
 import { Field, ObjectType, Type } from '../model';
 import {
     NullQueryNode, ObjectQueryNode, PropertySpecification, QueryNode, UnaryOperationQueryNode, UnaryOperator
 } from '../query-tree';
-import { CURSOR_FIELD } from '../schema/constants';
+import { CURSOR_FIELD, ID_FIELD, ORDER_BY_ASC_SUFFIX } from '../schema/constants';
+import { getMetaFieldName } from '../schema/names';
 import { flatMap } from '../utils/utils';
 import { EnumTypeGenerator } from './enum-type-generator';
 import { createFieldNode } from './field-nodes';
@@ -82,7 +82,9 @@ export class OutputTypeGenerator {
             return NullQueryNode.NULL;
         }
 
-        const clauses = getOrderByValues(listFieldRequest.args, orderByType);
+        // force the absolute-order-behavior we normally only have if the 'first' argument is present
+        // so one can use a _cursor value from a query without orderBy as 'after' argument without orderBy.
+        const clauses = getOrderByValues(listFieldRequest.args, orderByType, {forceAbsoluteOrder: true});
         const sortedClauses = sortBy(clauses, clause => clause.name);
         const objectNode = new ObjectQueryNode(sortedClauses.map(clause =>
             new PropertySpecification(clause.underscoreSeparatedPath, clause.getValueNode(itemNode))));

--- a/src/schema-generation/utils/pagination.ts
+++ b/src/schema-generation/utils/pagination.ts
@@ -1,13 +1,16 @@
 import { OrderDirection } from '../../query-tree';
-import { ID_FIELD, ORDER_BY_ARG } from '../../schema/constants';
+import { FIRST_ARG, ID_FIELD, ORDER_BY_ARG } from '../../schema/constants';
 import { OrderByEnumType, OrderByEnumValue } from '../order-by-enum-generator';
 
-export function getOrderByValues(args: any, orderByType: OrderByEnumType): ReadonlyArray<OrderByEnumValue> {
+export function getOrderByValues(args: any, orderByType: OrderByEnumType, {forceAbsoluteOrder = false}: { readonly forceAbsoluteOrder?: boolean } = {}): ReadonlyArray<OrderByEnumValue> {
     const valueNames = (args[ORDER_BY_ARG] || []) as ReadonlyArray<string>;
     const values = valueNames.map(value => orderByType.getValueOrThrow(value));
 
-    // If possible, add 'id' so that we have an absolute order
-    if (values.length > 0 && (orderByType.objectType.isChildEntityType || orderByType.objectType.isRootEntityType) && !valueNames.includes(ID_FIELD)) {
+    // if first is present, we are paginating, which only works when there is an absolute order
+    // To achieve this, we add the 'id' as sort clause
+    // Doesn't work on value objects though
+    const needsID = forceAbsoluteOrder || FIRST_ARG in args;
+    if (needsID && (orderByType.objectType.isChildEntityType || orderByType.objectType.isRootEntityType) && !valueNames.includes(ID_FIELD)) {
         return [
             ...values,
             new OrderByEnumValue([orderByType.objectType.getFieldOrThrow(ID_FIELD)], OrderDirection.ASCENDING)


### PR DESCRIPTION
The goal is to avoid pitfalls when using cursor-based pagination if no
absolute order is specified by the user and thus pagination would fail.
Thus, we add the 'id' sort clause if we detect the user is pagination -
this is when the 'first' argument is present . Otherwise, the cursors
may be fetched, but they likely are not used because all remaining items
are returned, anyway. But in case the cursors are fetched, we at least
don't want them to be empty or underspecified, so we add the 'id' clause
here, too. Then, a cursor from a selection without orderBy can be used
again as 'first' argument when no orderBy argument is specified.

Previously, 'id' has been added as sort clause if any other sort clauses
had been present. This did not cover all cases, and it added an
unnecessary order clause if no pagination was present.