### PR TITLE
entity-extensions-and-null

### DIFF
--- a/docs/modelling.md
+++ b/docs/modelling.md
@@ -81,7 +81,7 @@ type Order @rootEntity {
 }
 ```
 
-Entity extension can be used within root entities, child entities and other entity extensions. If you omit fields when updating an entity extension, those are kept as-is.
+Entity extension can be used within root entities, child entities and other entity extensions. If you omit fields when updating an entity extension, those are kept as-is. Entity extensions are never `null` - if you omit it entirely, or an object was created before it was added, the field evaluates to an empty object.
 
 ### Value objects
 

--- a/spec/regression/logistics/model/dangerous-goods.graphqls
+++ b/spec/regression/logistics/model/dangerous-goods.graphqls
@@ -1,5 +1,5 @@
 type DangerousGoodsInfo @entityExtension {
     unNumber: String
     flashpoint: String
-    notices: [ String ]
+    notices: [ String ] @defaultValue(value: ["No special treatment necessary."])
 }

--- a/spec/regression/logistics/tests/entity-extensions.graphql
+++ b/spec/regression/logistics/tests/entity-extensions.graphql
@@ -1,0 +1,61 @@
+query before {
+    # this one has dgInfo
+    withValue: Delivery(id: "@{ids/Delivery/1}") {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+
+    # this one doesn't
+    withoutValue: Delivery(id: "@{ids/Delivery/2}") {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+}
+
+mutation update {
+    updateDelivery(input: { id: "@{ids/Delivery/2}", dgInfo: { unNumber: "1234" } }) {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+}
+
+query afterUpdate {
+    Delivery(id: "@{ids/Delivery/2}") {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+}
+
+mutation updateWithNull {
+    updateDelivery(input: { id: "@{ids/Delivery/2}", dgInfo: null }) {
+        dgInfo {
+            unNumber
+        }
+    }
+}
+
+mutation createWithNull {
+    createDelivery(input: { dgInfo: null }) {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+}
+
+mutation createWithValue {
+    createDelivery(input: { dgInfo: { unNumber: "1234" } }) {
+        dgInfo {
+            unNumber
+            notices
+        }
+    }
+}

--- a/spec/regression/logistics/tests/entity-extensions.result.json
+++ b/spec/regression/logistics/tests/entity-extensions.result.json
@@ -1,0 +1,79 @@
+{
+  "before": {
+    "data": {
+      "withValue": {
+        "dgInfo": {
+          "unNumber": "1863",
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      },
+      "withoutValue": {
+        "dgInfo": {
+          "unNumber": null,
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      }
+    }
+  },
+  "update": {
+    "data": {
+      "updateDelivery": {
+        "dgInfo": {
+          "unNumber": "1234",
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      }
+    }
+  },
+  "afterUpdate": {
+    "data": {
+      "Delivery": {
+        "dgInfo": {
+          "unNumber": "1234",
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      }
+    }
+  },
+  "updateWithNull": {
+    "data": {
+      "updateDelivery": {
+        "dgInfo": {
+          "unNumber": "1234"
+        }
+      }
+    }
+  },
+  "createWithNull": {
+    "data": {
+      "createDelivery": {
+        "dgInfo": {
+          "unNumber": null,
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      }
+    }
+  },
+  "createWithValue": {
+    "data": {
+      "createDelivery": {
+        "dgInfo": {
+          "unNumber": "1234",
+          "notices": [
+            "No special treatment necessary."
+          ]
+        }
+      }
+    }
+  }
+}

--- a/spec/regression/logistics/tests/filter-null.graphql
+++ b/spec/regression/logistics/tests/filter-null.graphql
@@ -18,6 +18,7 @@ query filterNullValueObject {
 }
 
 query filterNullEntityExtension {
+    # this finds all root entities because null is coerced to {} for entity extensions
     allDeliveries(filter: { dgInfo: null }, orderBy: deliveryNumber_ASC) {
         id
     }

--- a/spec/regression/logistics/tests/filter-null.result.json
+++ b/spec/regression/logistics/tests/filter-null.result.json
@@ -39,6 +39,9 @@
     "data": {
       "allDeliveries": [
         {
+          "id": "@{ids/Delivery/1}"
+        },
+        {
           "id": "@{ids/Delivery/2}"
         },
         {

--- a/spec/schema-generation/create-input-type-generator.spec.ts
+++ b/spec/schema-generation/create-input-type-generator.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { GraphQLEnumType, GraphQLInputObjectType, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { ChildEntityType, Model, RootEntityType, TypeKind } from '../../src/model';
-import { CreateInputTypeGenerator, ObjectCreateInputField } from '../../src/schema-generation/create-input-types';
+import { CreateInputTypeGenerator, CreateObjectInputField } from '../../src/schema-generation/create-input-types';
 import { EnumTypeGenerator } from '../../src/schema-generation/enum-type-generator';
 
 describe('CreateInputTypeGenerator', () => {
@@ -380,17 +380,14 @@ describe('CreateInputTypeGenerator', () => {
                 expect(prepared.suit).to.deep.equal({color: 'black'});
             });
 
-            it('keeps null values', () => {
+            it('defaults to {} on null value', () => {
                 const prepared = inputType.prepareValue({suit: null}) as any;
-                expect(prepared.suit).to.be.null;
+                expect(prepared.suit).to.deep.equal({});
             });
 
-            it('does not include it if not specified', () => {
-                // TODO should it be this way?
-                // It is currently, but this also prevents defaultValues on the fields in the entity extension if
-                // the entity extension is omitted (or set to null, see above)
+            it('defaults to {} if not specified', () => {
                 const prepared = inputType.prepareValue({});
-                expect(prepared.suit).to.be.undefined;
+                expect(prepared.suit).to.deep.equal({});
             });
         });
 
@@ -572,7 +569,7 @@ describe('CreateInputTypeGenerator', () => {
         it('creates a cyclic object structure', () => {
             const inputType = generator.generate(model.getValueObjectTypeOrThrow('Node'));
             const parentField = inputType.fields.find(f => f.name == 'parent');
-            expect((parentField as ObjectCreateInputField).objectInputType).to.equal(inputType);
+            expect((parentField as CreateObjectInputField).objectInputType).to.equal(inputType);
         });
 
         it('creates a cyclic graphql input type structure', () => {

--- a/src/schema-generation/create-input-types/generator.ts
+++ b/src/schema-generation/create-input-types/generator.ts
@@ -4,7 +4,8 @@ import memorize from 'memorize-decorator';
 import { ChildEntityType, EntityExtensionType, Field, ObjectType, RootEntityType, ValueObjectType } from '../../model';
 import { EnumTypeGenerator } from '../enum-type-generator';
 import {
-    BasicCreateInputField, BasicListCreateInputField, CreateInputField, ObjectCreateInputField,
+    BasicCreateInputField, BasicListCreateInputField, CreateEntityExtensionInputField, CreateInputField,
+    CreateObjectInputField,
     ObjectListCreateInputField
 } from './input-fields';
 import {
@@ -86,9 +87,14 @@ export class CreateInputTypeGenerator {
             }
         }
 
+        if (field.type.isEntityExtensionType) {
+            const inputType = this.generateForEntityExtensionType(field.type);
+            return [new CreateEntityExtensionInputField(field, inputType)];
+        }
+
         // child entity, value object, entity extension
         const inputType = this.generate(field.type);
-        const inputField = field.isList ? new ObjectListCreateInputField(field, inputType) : new ObjectCreateInputField(field, inputType);
+        const inputField = field.isList ? new ObjectListCreateInputField(field, inputType) : new CreateObjectInputField(field, inputType);
         return [inputField];
     }
 }

--- a/src/schema-generation/create-input-types/input-fields.ts
+++ b/src/schema-generation/create-input-types/input-fields.ts
@@ -70,7 +70,7 @@ export class BasicListCreateInputField extends BasicCreateInputField {
     }
 }
 
-export class ObjectCreateInputField extends BasicCreateInputField {
+export class CreateObjectInputField extends BasicCreateInputField {
     constructor(
         field: Field,
         public readonly objectInputType: CreateObjectInputType,
@@ -131,5 +131,17 @@ export class ObjectListCreateInputField extends BasicCreateInputField {
         }
 
         value.forEach(value => this.objectInputType.collectAffectedFields(value, fields));
+    }
+}
+
+export class CreateEntityExtensionInputField extends CreateObjectInputField {
+    protected coerceValue(value: AnyValue): AnyValue {
+        // this should always be an object so the default values of entity extensions apply
+        return super.coerceValue(value == undefined ? {} : value);
+    }
+
+    appliesToMissingFields() {
+        // this is important because we always fall back to {} to get apply default values in the entity extension type
+        return true;
     }
 }

--- a/src/schema-generation/field-nodes.ts
+++ b/src/schema-generation/field-nodes.ts
@@ -2,7 +2,8 @@ import { RootEntityType } from '../model';
 import { Field } from '../model/implementation';
 import {
     BasicType, BinaryOperationQueryNode, BinaryOperator, ConditionalQueryNode, EntitiesQueryNode, FieldQueryNode,
-    FirstOfListQueryNode, FollowEdgeQueryNode, ListQueryNode, NullQueryNode, QueryNode, RootEntityIDQueryNode,
+    FirstOfListQueryNode, FollowEdgeQueryNode, ListQueryNode, NullQueryNode, ObjectQueryNode, QueryNode,
+    RootEntityIDQueryNode,
     TransformListQueryNode, TypeCheckQueryNode, VariableQueryNode
 } from '../query-tree';
 import { ID_FIELD } from '../schema/constants';
@@ -30,7 +31,12 @@ export function createFieldNode(field: Field, sourceNode: QueryNode): QueryNode 
         return new RootEntityIDQueryNode(sourceNode);
     }
 
-    return new FieldQueryNode(sourceNode, field);
+    const fieldNode = new FieldQueryNode(sourceNode, field);
+    if (field.type.isEntityExtensionType) {
+        return new ConditionalQueryNode(new TypeCheckQueryNode(fieldNode, BasicType.OBJECT), fieldNode, ObjectQueryNode.EMPTY);
+    }
+
+    return fieldNode;
 }
 
 function createTo1ReferenceNode(field: Field, sourceNode: QueryNode): QueryNode {

--- a/src/schema-generation/filter-input-types/filter-fields.ts
+++ b/src/schema-generation/filter-input-types/filter-fields.ts
@@ -115,6 +115,27 @@ export class NestedObjectFilterField implements FilterField {
     }
 }
 
+export class EntityExtensionFilterField implements FilterField {
+    readonly name: string;
+    readonly description: string;
+
+    constructor(
+        public readonly field: Field,
+        public readonly inputType: FilterObjectType
+    ) {
+        this.name = this.field.name;
+        this.description = `Allows to filter on the fields of \`${this.field.name}\`.\n\nNote that \`${this.field.name}\` is an entity extension and thus can never be \`null\`, so specifying \`null\` to this filter field has no effect.`;
+    }
+
+    getFilterNode(sourceNode: QueryNode, filterValue: AnyValue): QueryNode {
+        if (filterValue == undefined) {
+            // entity extensions can't ever be null, and null is always coerced to {}, so this filter just shouldn't have any effect
+            return ConstBoolQueryNode.TRUE;
+        }
+        return this.inputType.getFilterNode(createFieldNode(this.field, sourceNode), filterValue);
+    }
+}
+
 export interface ListFilterField extends FilterField {
     readonly inputType: FilterObjectType
     readonly field: Field

--- a/src/schema-generation/filter-input-types/generator.ts
+++ b/src/schema-generation/filter-input-types/generator.ts
@@ -13,7 +13,7 @@ import { resolveThunk } from '../query-node-object-type';
 import { TypedInputObjectType } from '../typed-input-object-type';
 import { and, ENUM_FILTER_FIELDS, FILTER_FIELDS_BY_TYPE, FILTER_OPERATORS, QUANTIFIERS } from './constants';
 import {
-    AndFilterField,
+    AndFilterField, EntityExtensionFilterField,
     FilterField, ListFilterField, NestedObjectFilterField, OrFilterField, QuantifierFilterField,
     ScalarOrEnumFieldFilterField,
     ScalarOrEnumFilterField
@@ -76,7 +76,11 @@ export class FilterTypeGenerator {
         }
         if (field.type.isObjectType) {
             const inputType = this.generate(field.type);
-            return [new NestedObjectFilterField(field, inputType)];
+            if (field.type.isEntityExtensionType) {
+                return [new EntityExtensionFilterField(field, inputType)];
+            } else {
+                return [new NestedObjectFilterField(field, inputType)];
+            }
         }
         if (field.type.isEnumType) {
             const graphQLEnumType = this.enumTypeGenerator.generate(field.type);

--- a/src/schema/graphql-base.ts
+++ b/src/schema/graphql-base.ts
@@ -2,45 +2,45 @@ import gql from 'graphql-tag';
 import { DocumentNode } from 'graphql';
 
 export const DIRECTIVES: DocumentNode = gql`
-    # Declares a type for root-level objects with ids that are stored directly in the data base
+    "Declares a type for root-level objects with ids that are stored directly in the data base"
     directive @rootEntity(indices: [IndexDefinition!], permissionProfile: String) on OBJECT
     
-    # Declares a type for objects with ids that can be embedded as a list within another entity
+    "Declares a type for objects with ids that can be embedded as a list within another entity"
     directive @childEntity on OBJECT
     
-    # Declares a type for objects without id that can be embedded everywhere and can only be replaced as a whole
+    "Declares a type for objects without id that can be embedded everywhere and can only be replaced as a whole"
     directive @valueObject on OBJECT
     
-    # Declares a type for objects which can be embedded within entities or entity extensions
+    "Declares a type for objects which can be embedded within entities or entity extensions"
     directive @entityExtension on OBJECT
     
-    # Declares a field as a to-1 or to-n relation to another root entity
+    "Declares a field as a to-1 or to-n relation to another root entity"
     directive @relation(inverseOf: String) on FIELD_DEFINITION
     
-    # Declares a field to reference another root entity via its @key
+    "Declares a field to reference another root entity via its @key"
     directive @reference on FIELD_DEFINITION
     
-    # Declares a field as business key which is used in @reference fields
+    "Declares a field as business key which is used in @reference fields"
     directive @key on FIELD_DEFINITION
 
-    # Declares a field to be indexed
+    "Declares a field to be indexed"
     directive @index on FIELD_DEFINITION
 
-    # Declares a field to be unique-indexed
+    "Declares a field to be unique-indexed"
     directive @unique on FIELD_DEFINITION
 
-    # Specifies the namespace of a type
+    "Specifies the namespace of a type"
     directive @namespace(name: String!) on OBJECT
     
-    # Specifies the roles that can access objects of this type
+    "Specifies the roles that can access objects of this type"
     directive @roles(
-        # A list of roles that are authorized to read objects of this type
+        "A list of roles that are authorized to read objects of this type"
         read: [String!]
-        # A list of roles that are authorized to read, create, update and delete objects of this type
+        "A list of roles that are authorized to read, create, update and delete objects of this type"
         readWrite: [String!])
     on FIELD_DEFINITION|OBJECT
 
-    # Specifies the indices of a root entity
+    "Specifies the indices of a root entity"
     directive @indices(
             indices: [IndexDefinition!]
         )
@@ -55,13 +55,13 @@ export const DIRECTIVES: DocumentNode = gql`
         APPEND,
         PREPEND
     }    
-    # Specifies which special calculation update mutations should be generated for this field
+    "Specifies which special calculation update mutations should be generated for this field"
     directive @calcMutations(
-        # A list of operators. For each operator a update calculation mutation will be generated
+        "A list of operators. For each operator a update calculation mutation will be generated"
         operators: [CalcMutationsOperator!])
     on FIELD_DEFINITION
 
-    # Specifies the defaultValue of a field
+    ""
     directive @defaultValue(value: JSON!) on FIELD_DEFINITION
     
     input IndexDefinition {


### PR DESCRIPTION
Now, entity extension can't ever be null, which is always coerced to {}.
