### PR TITLE
Improve performance of count queries

### DIFF
--- a/spec/regression/logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/logistics/tests/field-permission-denied.result.json
@@ -106,6 +106,19 @@
         "message": "AuthorizationError: Not authorized to read Forwarder objects",
         "locations": [
           {
+            "line": 42,
+            "column": 9
+          }
+        ],
+        "path": [
+          "_allForwardersMeta",
+          "count"
+        ]
+      },
+      {
+        "message": "AuthorizationError: Not authorized to read Forwarder objects",
+        "locations": [
+          {
             "line": 37,
             "column": 5
           }
@@ -113,21 +126,14 @@
         "path": [
           "allForwarders"
         ]
-      },
-      {
-        "message": "AuthorizationError: Not authorized to read Forwarder objects",
-        "locations": [
-          {
-            "line": 41,
-            "column": 5
-          }
-        ],
-        "path": [
-          "_allForwardersMeta"
-        ]
       }
     ],
-    "data": null
+    "data": {
+      "allForwarders": null,
+      "_allForwardersMeta": {
+        "count": null
+      }
+    }
   },
   "filter": {
     "errors": [

--- a/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
@@ -138,18 +138,24 @@
         "message": "AuthorizationError: Not authorized to read Forwarder objects",
         "locations": [
           {
-            "line": 52,
-            "column": 9
+            "line": 53,
+            "column": 13
           }
         ],
         "path": [
           "logistics",
-          "_allForwardersMeta"
+          "_allForwardersMeta",
+          "count"
         ]
       }
     ],
     "data": {
-      "logistics": null
+      "logistics": {
+        "allForwarders": null,
+        "_allForwardersMeta": {
+          "count": null
+        }
+      }
     }
   },
   "filter": {

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -327,6 +327,7 @@ register(CountQueryNode, (node, context) => {
     // because it avoids building the whole collection temporarily in memory
     // however, https://docs.arangodb.com/3.2/AQL/Examples/Counting.html does not really mention this case, so we
     // should evaluate it again
+    // note that ArangoDB's inline-subqueries rule optimizes for the case where listNode is a TransformList again.
     const itemVar = aql.variable('item');
     const countVar = aql.variable('count');
     return aqlExt.parenthesizeObject(

--- a/src/schema-generation/output-type-generator.ts
+++ b/src/schema-generation/output-type-generator.ts
@@ -135,6 +135,7 @@ export class OutputTypeGenerator {
         const plainField: QueryNodeField = {
             name: getMetaFieldName(field.name),
             type: new QueryNodeNonNullType(metaType),
+            skipNullCheck: true, // meta fields should never be null
             description: field.description,
             resolve: (sourceNode) => createFieldNode(field, sourceNode)
         };

--- a/src/schema-generation/query-node-object-type/definition.ts
+++ b/src/schema-generation/query-node-object-type/definition.ts
@@ -20,6 +20,14 @@ export interface QueryNodeField {
      * Indicates whether this field should be resolved in the user-specified sequence among other serial fields
      */
     isSerial?: boolean
+
+    /**
+     * If set to `true`, the resolved value is not checked against NULL
+     *
+     * Normally, fields whose type is an object type evaluate to NULL if the source value is NULL. If this flag is set,
+     * NULL is passed to the field resolvers within.
+     */
+    skipNullCheck?: boolean
 }
 
 export interface QueryNodeObjectType {

--- a/src/schema-generation/query-node-object-type/query-node-generator.ts
+++ b/src/schema-generation/query-node-object-type/query-node-generator.ts
@@ -1,9 +1,5 @@
 import { FieldRequest, FieldSelection } from '../../graphql/query-distiller';
-import {
-    BasicType, ConditionalQueryNode, NullQueryNode, ObjectQueryNode, PreExecQueryParms, PropertySpecification,
-    QueryNode, TransformListQueryNode, TypeCheckQueryNode, VariableAssignmentQueryNode, VariableQueryNode,
-    WithPreExecutionQueryNode
-} from '../../query-tree';
+import { BasicType, ConditionalQueryNode, NullQueryNode, ObjectQueryNode, PreExecQueryParms, PropertySpecification, QueryNode, TransformListQueryNode, TypeCheckQueryNode, VariableAssignmentQueryNode, VariableQueryNode, WithPreExecutionQueryNode } from '../../query-tree';
 import { decapitalize } from '../../utils/utils';
 import { QueryNodeField, QueryNodeObjectType } from './definition';
 import { extractQueryTreeObjectType, isListType, resolveThunk } from './utils';
@@ -81,11 +77,14 @@ function buildFieldQueryNode0(sourceNode: QueryNode, field: QueryNodeField, fiel
         // This is no longer necessary because createFieldNode() already does this where necessary (only for simple field lookups)
         // All other code should return lists where lists are expected
         return buildTransformListQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
+    }
+
+    // object
+    if (field.skipNullCheck) {
+        return buildObjectQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
     } else {
         // This is necessary because we want to return `null` if a field is null, and not pass `null` through as
         // `source`, just as the graphql engine would do, too.
-        // It currently also treats non-objects as `null` (just because it's free), but we may move this to
-        // createFieldNode() later.
         return buildConditionalObjectQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
     }
 }

--- a/src/schema-generation/query-type-generator.ts
+++ b/src/schema-generation/query-type-generator.ts
@@ -86,6 +86,10 @@ export class QueryTypeGenerator {
             name: getMetaFieldName(getAllEntitiesFieldName(rootEntityType.name)),
             type: new QueryNodeNonNullType(metaType),
             description: rootEntityType.description,
+            // meta fields should never be null. Also, this is crucial for performance. Without it, we would introduce
+            // an unnecessary variable with the collection contents (which is slow) and we would to an equality check of
+            // a collection against NULL which is deadly (v8 evaluation)
+            skipNullCheck: true,
             resolve: () => this.getAllRootEntitiesNode(rootEntityType)
         });
         return this.filterAugmentation.augment(fieldConfig, rootEntityType);

--- a/src/schema-generation/utils/filtering.ts
+++ b/src/schema-generation/utils/filtering.ts
@@ -1,13 +1,19 @@
 import { Type } from '../../model';
-import { QueryNode, TransformListQueryNode, VariableQueryNode } from '../../query-tree';
+import { ConstBoolQueryNode, QueryNode, TransformListQueryNode, VariableQueryNode } from '../../query-tree';
 import { FILTER_ARG } from '../../schema/constants';
 import { decapitalize } from '../../utils/utils';
 import { FilterObjectType } from '../filter-input-types';
 
-export function buildFilteredListNode(listNode: QueryNode, args: {[name: string]: any}, filterType: FilterObjectType, itemType: Type) {
+export function buildFilteredListNode(listNode: QueryNode, args: { [name: string]: any }, filterType: FilterObjectType, itemType: Type) {
     const filterValue = args[FILTER_ARG] || {};
     const itemVariable = new VariableQueryNode(decapitalize(itemType.name));
     const filterNode = filterType.getFilterNode(itemVariable, filterValue);
+
+    // avoid unnecessary TransformLists especially for count queries, so that it can be optimized to LENGTH(collection)
+    if (filterNode === ConstBoolQueryNode.TRUE) {
+        return listNode;
+    }
+
     return new TransformListQueryNode({
         listNode,
         itemVariable,


### PR DESCRIPTION
Previously, we treated the collection as array which is highly
inefficient. This was a regression from version 0.5.

before:

```
[1 / 4] Count all of 1000 root entities...
  7.136ms (±14.37%) per iteration
  37s elapsed (18% for setup) for 4198 iterations in 16 cycles

[2 / 4] Count all of 1000000 root entities...
  5688.454ms (±63.62%) per iteration
  49s elapsed (31% for setup) for 6 iterations in 6 cycles

[3 / 4] Count about half of 1000 root entities...
  14.501ms (±5.17%) per iteration
  31s elapsed (2% for setup) for 2069 iterations in 13 cycles

[4 / 4] Count about half of 1000000 root entities...
  2383.355ms (±27.08%) per iteration
  41s elapsed (30% for setup) for 12 iterations in 7 cycles
```


now:

```
[1 / 4] Count all of 1000 root entities...
5.451ms (±1.82%) per iteration
21s elapsed (3% for setup) for 3710 iterations in 9 cycles

[2 / 4] Count all of 1000000 root entities...
7.426ms (±6.03%) per iteration
40s elapsed (25% for setup) for 4046 iterations in 10 cycles

[3 / 4] Count about half of 1000 root entities...
7.213ms (±1.99%) per iteration
16s elapsed (2% for setup) for 2172 iterations in 7 cycles

[4 / 4] Count about half of 1000000 root entities...
968.006ms (±16.43%) per iteration
43s elapsed (30% for setup) for 31 iterations in 14 cycles
`` 