### PR TITLE
Use indices for @reference lookup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -152,8 +152,7 @@
     "@types/node": {
       "version": "8.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
-      "integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
-      "dev": true
+      "integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg=="
     },
     "@types/pluralize": {
       "version": "0.0.27",
@@ -317,17 +316,15 @@
       }
     },
     "arangojs": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-5.7.1.tgz",
-      "integrity": "sha512-6KcIFdxphJsUZTqBuDlgqaSe3qbE2L+v6VquU96FGYh3ZOERwtgpGk9ZHE/sBBqjPsY2cgCQYyqeM80ahGr3EQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-6.6.0.tgz",
+      "integrity": "sha512-2Mkp4FpshhAisXlHoo+zg3gHyaFPWWY0mu0gplv2raoW4lRdohlntq2q+o1LQrtBzQ5r/pRUveTMmYJAUzkpaA==",
       "requires": {
+        "@types/node": "*",
         "es6-error": "^4.0.1",
-        "http-errors": "^1.6.1",
         "linkedlist": "^1.0.1",
         "multi-part": "^2.0.0",
-        "retry": "^0.10.0",
-        "utf8-length": "^0.0.1",
-        "xhr": "^2.3.1"
+        "xhr": "^2.4.1"
       }
     },
     "argparse": {
@@ -697,7 +694,8 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "dependency-check": {
       "version": "2.10.1",
@@ -972,11 +970,11 @@
       }
     },
     "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-function": "~1.0.0"
+        "is-callable": "^1.1.3"
       }
     },
     "forwarded": {
@@ -1301,6 +1299,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -1336,13 +1335,19 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-function": {
       "version": "1.0.1",
@@ -4506,11 +4511,6 @@
         "path-parse": "^1.0.5"
       }
     },
-    "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-    },
     "rfdc": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
@@ -4610,7 +4610,8 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -4645,7 +4646,8 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "streamroller": {
       "version": "0.7.0",
@@ -4682,7 +4684,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4873,11 +4875,6 @@
         }
       }
     },
-    "utf8-length": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
-      "integrity": "sha1-0xXEvtUpyXfxjdNcc9cmKDJ9mto="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4923,9 +4920,9 @@
       }
     },
     "xhr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
         "global": "~4.3.0",
         "is-function": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "ajv": "^6.0.1",
     "ansi-styles": "^3.2.1",
-    "arangojs": "~5.7.1",
+    "arangojs": "^6.6.0",
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^4.0.0",
     "graphql-transformer": "^0.2.0",

--- a/spec/database/arangodb/arangodb-adapter.spec.ts
+++ b/spec/database/arangodb/arangodb-adapter.spec.ts
@@ -90,6 +90,15 @@ describe('ArangoDBAdapter', () => {
                     sparse: true,
                     type: 'persistent',
                     unique: true
+                },
+                // this one is for @reference lookup which needs a non-sparse (see shouldUseWorkaroundForSparseIndices)
+                {
+                    fields: [
+                        'deliveryNumber'
+                    ],
+                    sparse: false,
+                    type: 'persistent',
+                    unique: false
                 }
             ]);
 

--- a/spec/database/arangodb/arangodb-adapter.spec.ts
+++ b/spec/database/arangodb/arangodb-adapter.spec.ts
@@ -53,7 +53,7 @@ describe('ArangoDBAdapter', () => {
             await adapter.updateSchema(model);
 
             const indices = await db.collection('deliveries').indexes();
-            expect(indices.map(index => ({
+            expect(indices.map((index: any) => ({
                 fields: index.fields,
                 sparse: index.sparse,
                 type: index.type,
@@ -94,7 +94,7 @@ describe('ArangoDBAdapter', () => {
             ]);
 
             const indicesOnOtherCollection = await db.collection('second').indexes();
-            expect(indicesOnOtherCollection.map(index => ({
+            expect(indicesOnOtherCollection.map((index: any) => ({
                 fields: index.fields,
                 sparse: index.sparse,
                 type: index.type,

--- a/spec/performance/associations.perf.ts
+++ b/spec/performance/associations.perf.ts
@@ -36,7 +36,7 @@ async function setUpPapersAndReaders(environment: TestEnvironment, config: { pap
 
 function testFetchWithAssociations(config: { paperCount: number, userCount: number, associationCount: number }): BenchmarkConfig {
     let env: TestEnvironment;
-    let sampledIDs: number[] = [];
+    let sampledIDs: string[] = [];
     return {
         name: `Fetch one of one root entity with one level deep associations (${config.paperCount} papers, ${config.userCount} users, ${config.associationCount} associations`,
         async beforeAll() {

--- a/spec/performance/crud.perf.ts
+++ b/spec/performance/crud.perf.ts
@@ -32,7 +32,7 @@ function getSelectionSet(config: { onlyFewFields?: boolean }) {
 
 function getOneOfXRootEntities(config: { rootEntitiesInDB: number, documentLength: number, onlyFewFields?: boolean }): BenchmarkConfig {
     let env: TestEnvironment;
-    let sampledIDs: number[] = [];
+    let sampledIDs: string[] = [];
     const sizeFactor = getSizeFactorForJSONLength(config.documentLength);
     return {
         name: `Get ${config.onlyFewFields ? 'two fields of ' : ''} one of ${config.rootEntitiesInDB} root entities of size ${formatBytes(config.documentLength)}`,

--- a/spec/performance/index.ts
+++ b/spec/performance/index.ts
@@ -4,11 +4,13 @@ import {default as PAGINATION} from "./pagination.perf";
 import {default as COUNT} from "./count.perf";
 import {default as ASSOCIATIONS} from "./associations.perf";
 import {default as QUERY_PIPELINE} from "./query-pipeline.perf";
+import {default as REFERENCES} from "./references.perf";
 
 runBenchmarks([
     ...CRUD,
     ...PAGINATION,
     ...COUNT,
+    ...REFERENCES,
     ...ASSOCIATIONS,
     ...QUERY_PIPELINE
 ]);

--- a/spec/performance/references.perf.ts
+++ b/spec/performance/references.perf.ts
@@ -1,0 +1,70 @@
+import { BenchmarkConfig, BenchmarkFactories } from './support/async-bench';
+import { takeRandomSample } from '../../src/utils/utils';
+import {
+    addManyPapersWithAQL, addManyUsersWithAQL, aql, createLargePaper, createUser, getRandomPaperIDsWithAQL,
+    initEnvironment, TestEnvironment
+} from './support/helpers';
+
+
+async function setUpPapers(environment: TestEnvironment, config: { startIndex: number, paperCount: number, referenceCountEach: number}) {
+    await environment.getDB().query(aql`
+        FOR i IN ${config.startIndex}..${config.startIndex + config.paperCount - 1}
+        INSERT {
+            key: TO_STRING(i),
+            title: CONCAT("Paper ", i),
+            literatureReferences: (
+                FOR j IN 1..${config.referenceCountEach}
+                LET index = FLOOR(RAND() * ${config.paperCount})
+                RETURN {
+                    paper: TO_STRING(index),
+                    title: CONCAT("Paper ", index)
+                }   
+            )
+        } IN papers`);
+}
+
+function testReferenceLookup(config: { paperCount: number, referenceCountEach: number }): BenchmarkConfig {
+    let env: TestEnvironment;
+    let sampledIDs: string[] = [];
+    return {
+        name: `Set up ${config.paperCount} root entities with ${config.referenceCountEach} references each, then fetch a random root entity with all its references`,
+        async beforeAll() {
+            env = await initEnvironment();
+            await setUpPapers(env, {...config, startIndex: 0, paperCount: 1});
+            await setUpPapers(env, {...config, startIndex: 1, paperCount: config.paperCount - 1});
+        },
+
+        async before({count}) {
+            sampledIDs = await getRandomPaperIDsWithAQL(env, count);
+        },
+
+        async fn() {
+            const id = takeRandomSample(sampledIDs);
+            const result = await env.exec(`
+            query($id: ID!) { 
+                Paper(id: $id) { 
+                    id
+                    literatureReferences {
+                        title
+                        paper {
+                            key
+                            title
+                        }
+                    }
+                }
+            }`, {
+                id
+            });
+            if (result.Paper.id != id) {
+                throw new Error(`Unexpected result: ${JSON.stringify(result)}`);
+            }
+        }
+    };
+}
+
+const benchmarks: BenchmarkFactories = [
+    () => testReferenceLookup({paperCount: 1000, referenceCountEach: 50}),
+    () => testReferenceLookup({paperCount: 100000, referenceCountEach: 50})
+];
+
+export default benchmarks;

--- a/spec/performance/support/helpers.ts
+++ b/spec/performance/support/helpers.ts
@@ -38,7 +38,7 @@ export async function initEnvironment(): Promise<TestEnvironment> {
 
     return {
         getDB() {
-            return new Database(dbConfig)
+            return new Database(dbConfig).useDatabase(dbConfig.databaseName)
         },
         async exec(gql, variables) {
             const res = await graphql(schema, gql, {} /* root */, {authRoles: ['admin']}, variables);
@@ -98,10 +98,10 @@ export async function addManyUsersWithAQL(environment: TestEnvironment, count: n
     await environment.getDB().query(aql`FOR i IN 1..${count} INSERT ${userData} IN users`);
 }
 
-export async function getRandomPaperIDsWithAQL(environment: TestEnvironment, count: number): Promise<number[]> {
+export async function getRandomPaperIDsWithAQL(environment: TestEnvironment, count: number): Promise<string[]> {
     const cursor = await environment.getDB().query(aql`FOR node IN papers SORT RAND() LIMIT ${count} RETURN { id: node._key }`);
     const docs = await cursor.all();
-    return docs.map(doc => doc.id);
+    return docs.map((doc: any) => doc.id);
 }
 
 export function formatBytes(bytes: number): string {

--- a/spec/regression/initialization.ts
+++ b/spec/regression/initialization.ts
@@ -1,4 +1,4 @@
-import { Database } from 'arangojs';
+import { Database, DocumentCollection, EdgeCollection } from 'arangojs';
 import * as fs from 'fs';
 import { ExecutionResult, graphql, GraphQLSchema } from 'graphql';
 import { ArangoDBConfig } from '../../src/database/arangodb/arangodb-adapter';
@@ -14,7 +14,7 @@ export async function createTempDatabase(): Promise<ArangoDBConfig> {
     const dbs = await db.listDatabases();
     if (dbs.indexOf(DATABASE_NAME) >= 0) {
         db.useDatabase(DATABASE_NAME);
-        const colls = await db.collections(true);
+        const colls = (await db.collections(true)) as (DocumentCollection | EdgeCollection)[];
         await Promise.all(colls.map(coll => coll.drop()));
     } else {
         await db.createDatabase(DATABASE_NAME);

--- a/src/database/arangodb/arangodb-adapter.ts
+++ b/src/database/arangodb/arangodb-adapter.ts
@@ -155,8 +155,10 @@ export class ArangoDBAdapter implements DatabaseAdapter {
         await Promise.all(createTasks);
         this.logger.info(`Done`);
 
+        const shouldUseWorkaroundForSparseIndices = await this.shouldUseWorkaroundForSparseIndices();
+
         // update indices
-        const requiredIndices = getRequiredIndicesFromModel(model);
+        const requiredIndices = getRequiredIndicesFromModel(model, { shouldUseWorkaroundForSparseIndices });
         const existingIndicesPromises = model.rootEntityTypes.map(rootEntityType => this.getCollectionIndices(rootEntityType));
         let existingIndices: IndexDefinition[] = [];
         await Promise.all(existingIndicesPromises).then(promiseResults => promiseResults.forEach(indices => indices.forEach(index => existingIndices.push(index))));
@@ -180,7 +182,7 @@ export class ArangoDBAdapter implements DatabaseAdapter {
         const createIndicesPromises = indicesToCreate.map(indexToCreate => {
             const collection = getCollectionNameForRootEntity(indexToCreate.rootEntity);
             if (this.autocreateIndices) {
-                this.logger.info(`Creating ${ indexToCreate.unique ? 'unique ' : ''}index on collection ${collection} on ${indexToCreate.fields.length > 1 ? 'fields' : 'field'} '${indexToCreate.fields.join(',')}'`);
+                this.logger.info(`Creating ${ indexToCreate.unique ? 'unique ' : ''}${ indexToCreate.sparse ? 'sparse ' : ''}index on collection ${collection} on ${indexToCreate.fields.length > 1 ? 'fields' : 'field'} '${indexToCreate.fields.join(',')}'`);
                 return this.db.collection(collection).createIndex({
                     fields: indexToCreate.fields,
                     unique: indexToCreate.unique,
@@ -210,5 +212,54 @@ export class ArangoDBAdapter implements DatabaseAdapter {
         return result.map((index: any) => {
             return { ...index, rootEntity: rootEntityType };
         });
+    }
+
+    private async getArangoDBVersion(): Promise<string | undefined> {
+        const result = await this.db.route('_api').get('version');
+        if (!result || !result.body || !result.body.version) {
+            return undefined;
+        }
+        return result.body.version;
+    }
+
+    private parseVersion(version: string): { major: number, minor: number, patch: number } | undefined {
+        const parts = version.split('.');
+        if (parts.length < 3) {
+            return undefined;
+        }
+        const numParts = parts.slice(0, 3).map(p => parseInt(p, 10));
+        if (numParts.some(p => !isFinite(p))) {
+            return undefined;
+        }
+        const [major, minor, patch] = numParts;
+        return { major, minor, patch };
+    }
+
+    private async shouldUseWorkaroundForSparseIndices(): Promise<boolean> {
+        // arangodb <= 3.2 does not support dynamic usage of sparse indices
+        // We use unique indices for @key, and we enable sparse for all unique indices to support multiple NULL values
+        // however, this means we can't use the unique index for @reference lookups. To ensure this is still fast
+        // (as one would expect for a @reference), we create a non-sparse, non-unique index in addition to the regular
+        // unique sparse index.
+        let version;
+        try {
+            version = await this.getArangoDBVersion();
+        } catch (e) {
+            this.logger.warn(`Error fetching ArangoDB version. Workaround for sparse indices will not be enabled. ` + e.stack);
+            return false;
+        }
+        const parsed = version && this.parseVersion(version);
+        if (!parsed) {
+            this.logger.warn(`ArangoDB version not recognized ("${version}"). Workaround for sparse indices will not be enabled.`);
+            return false;
+        }
+
+        const { major, minor } = parsed;
+        if ((major > 3) || (major === 3 && minor >= 4)) {
+            this.logger.info(`ArangoDB version: ${version}. Workaround for sparse indices will not be enabled.`);
+            return false;
+        }
+        this.logger.info(`ArangoDB version: ${version}. Workaround for sparse indices will be enabled.`);
+        return true;
     }
 }


### PR DESCRIPTION
Currently, we create unique sparse indices on @key fields. However, sparse indices are not usable for reference lookup before arangodb 3.4. For the meantime, this adds a workaround that creates non-sparse non-unique indices for keys.

before:

```
[1 / 2] Set up 1000 root entities with 50 references each, then fetch a random root entity with all its references...
38.231ms (±1.98%) per iteration
14s elapsed (24% for setup) for 286 iterations in 5 cycles

[2 / 2] Set up 100000 root entities with 50 references each, then fetch a random root entity with all its references...
3996.238ms (±5.29%) per iteration
55s elapsed (49% for setup) for 7 iterations in 7 cycles
```

after:

```
[1 / 1] Set up 1000 root entities with 50 references each, then fetch a random root entity with all its references...
17.260ms (±2.46%) per iteration
32s elapsed (5% for setup) for 1741 iterations in 13 cycles

[1 / 1] Set up 100000 root entities with 50 references each, then fetch a random root entity with all its references...
14.565ms (±3.09%) per iteration
75s elapsed (60% for setup) for 2053 iterations in 16 cycles
```