### PR TITLE
Index fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ node_js:
 install:
   - npm ci
 script:
-  - mkdir -p arangodb-bin && cd arangodb-bin && curl -L https://download.arangodb.com/travisCI/setup_arangodb_3.2.4.sh
-      | bash > /dev/null
+  - mkdir -p arangodb-bin && cd arangodb-bin && ../tools/setup-arangodb.sh > /dev/null
   - npm run test:coverage
   - npm run test:dropdb
   - cd ..

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,6 +685,16 @@
       "integrity": "sha1-9dJgKStmDghO/0zbyfCK0yR0SLU=",
       "dev": true
     },
+    "deep-equal-in-any-order": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/deep-equal-in-any-order/-/deep-equal-in-any-order-1.0.10.tgz",
+      "integrity": "sha512-hzh3IwlIKwT885r5b/b4bXCXxzR7S9N+Dreuoommdykcnvlg0A+pS81wMU4ZsFz98CH4KBI8eWbAfDHWl7akTg==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.10",
+        "sort-any": "^1.1.12"
+      }
+    },
     "defined": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
@@ -4612,6 +4622,15 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
       "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
       "dev": true
+    },
+    "sort-any": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/sort-any/-/sort-any-1.1.12.tgz",
+      "integrity": "sha512-RaVPeOjzn5tjhAfvQstA34gPiG/HT+1MefSsG0KHIMhXjLlZREYSIkxlYaCRvdwLKNgpsgM6nvpLEY1Y0Ja9FQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4"
+      }
     },
     "source-map": {
       "version": "0.6.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -152,8 +152,7 @@
     "@types/node": {
       "version": "8.10.15",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.15.tgz",
-      "integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg==",
-      "dev": true
+      "integrity": "sha512-qNb+m5Cuj6YUMK7YFcvuSgcHCKfVg1uXAUOP91SWvAakZlZTzbGmJaBi99CgDWEAyfZo51NlUhXkuP5WtXsgjg=="
     },
     "@types/pluralize": {
       "version": "0.0.27",
@@ -317,17 +316,15 @@
       }
     },
     "arangojs": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-5.7.1.tgz",
-      "integrity": "sha512-6KcIFdxphJsUZTqBuDlgqaSe3qbE2L+v6VquU96FGYh3ZOERwtgpGk9ZHE/sBBqjPsY2cgCQYyqeM80ahGr3EQ==",
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/arangojs/-/arangojs-6.6.0.tgz",
+      "integrity": "sha512-2Mkp4FpshhAisXlHoo+zg3gHyaFPWWY0mu0gplv2raoW4lRdohlntq2q+o1LQrtBzQ5r/pRUveTMmYJAUzkpaA==",
       "requires": {
+        "@types/node": "*",
         "es6-error": "^4.0.1",
-        "http-errors": "^1.6.1",
         "linkedlist": "^1.0.1",
         "multi-part": "^2.0.0",
-        "retry": "^0.10.0",
-        "utf8-length": "^0.0.1",
-        "xhr": "^2.3.1"
+        "xhr": "^2.4.1"
       }
     },
     "argparse": {
@@ -697,7 +694,8 @@
     "depd": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
     },
     "dependency-check": {
       "version": "2.10.1",
@@ -972,11 +970,11 @@
       }
     },
     "for-each": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.2.tgz",
-      "integrity": "sha1-LEBFC5NI6X8oEyJZO6lnBLmr1NQ=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
+      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-function": "~1.0.0"
+        "is-callable": "^1.1.3"
       }
     },
     "forwarded": {
@@ -1301,6 +1299,7 @@
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
       "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
       "requires": {
         "depd": "~1.1.2",
         "inherits": "2.0.3",
@@ -1336,13 +1335,19 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ipaddr.js": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
       "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4=",
       "dev": true
+    },
+    "is-callable": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.4.tgz",
+      "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
     },
     "is-function": {
       "version": "1.0.1",
@@ -4506,11 +4511,6 @@
         "path-parse": "^1.0.5"
       }
     },
-    "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
-    },
     "rfdc": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.1.2.tgz",
@@ -4610,7 +4610,8 @@
     "setprototypeof": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
     },
     "source-map": {
       "version": "0.6.1",
@@ -4645,7 +4646,8 @@
     "statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
+      "dev": true
     },
     "streamroller": {
       "version": "0.7.0",
@@ -4682,7 +4684,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "http://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "dev": true,
           "requires": {
@@ -4873,11 +4875,6 @@
         }
       }
     },
-    "utf8-length": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/utf8-length/-/utf8-length-0.0.1.tgz",
-      "integrity": "sha1-0xXEvtUpyXfxjdNcc9cmKDJ9mto="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -4923,9 +4920,9 @@
       }
     },
     "xhr": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.4.1.tgz",
-      "integrity": "sha512-pAIU5vBr9Hiy5cpFIbPnwf0C18ZF86DBsZKrlsf87N5De/JbA6RJ83UP/cv+aljl4S40iRVMqP4pr4sF9Dnj0A==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
+      "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
         "global": "~4.3.0",
         "is-function": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "chai": "^4.1.2",
     "chai-as-promised": "^7.1.1",
     "deep-equal": "^1.0.1",
+    "deep-equal-in-any-order": "^1.0.10",
     "dependency-check": "^2.9.1",
     "graphql": "^14.0.2",
     "graphql-request": "^1.8.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "ajv": "^6.0.1",
     "ansi-styles": "^3.2.1",
-    "arangojs": "~5.7.1",
+    "arangojs": "^6.6.0",
     "graphql-tag": "^2.9.2",
     "graphql-tools": "^4.0.0",
     "graphql-transformer": "^0.2.0",

--- a/spec/database/arangodb/arangodb-adapter.spec.ts
+++ b/spec/database/arangodb/arangodb-adapter.spec.ts
@@ -83,6 +83,15 @@ describe('ArangoDBAdapter', () => {
                     type: 'persistent',
                     unique: false
                 },
+                // this one is for @reference lookup which needs a non-sparse (see shouldUseWorkaroundForSparseIndices)
+                {
+                    fields: [
+                        'deliveryNumber'
+                    ],
+                    sparse: false,
+                    type: 'persistent',
+                    unique: false
+                },
                 {
                     fields: [
                         'deliveryNumber'

--- a/spec/database/arangodb/arangodb-adapter.spec.ts
+++ b/spec/database/arangodb/arangodb-adapter.spec.ts
@@ -58,7 +58,7 @@ describe('ArangoDBAdapter', () => {
                 sparse: index.sparse,
                 type: index.type,
                 unique: index.unique
-            }))).to.deep.equal([
+            }))).to.deep.equalInAnyOrder([
                 {
                     fields: [
                         '_key'
@@ -69,7 +69,8 @@ describe('ArangoDBAdapter', () => {
                 },
                 {
                     fields: [
-                        'itemCount'
+                        'isShipped',
+                        '_key' // for absolute ordering
                     ],
                     sparse: false,
                     type: 'persistent',
@@ -77,7 +78,8 @@ describe('ArangoDBAdapter', () => {
                 },
                 {
                     fields: [
-                        'isShipped'
+                        'itemCount',
+                        '_key' // for absolute ordering
                     ],
                     sparse: false,
                     type: 'persistent',
@@ -86,7 +88,17 @@ describe('ArangoDBAdapter', () => {
                 // this one is for @reference lookup which needs a non-sparse (see shouldUseWorkaroundForSparseIndices)
                 {
                     fields: [
-                        'deliveryNumber'
+                        'deliveryNumber',
+                        '_key' // for absolute ordering
+                    ],
+                    sparse: false,
+                    type: 'persistent',
+                    unique: false
+                },
+                // for automatic absolute ordering
+                {
+                    fields: [
+                        '_key'
                     ],
                     sparse: false,
                     type: 'persistent',
@@ -99,7 +111,7 @@ describe('ArangoDBAdapter', () => {
                     sparse: true,
                     type: 'persistent',
                     unique: true
-                }
+                },
             ]);
 
             const indicesOnOtherCollection = await db.collection('second').indexes();

--- a/spec/database/arangodb/arangodb-adapter.spec.ts
+++ b/spec/database/arangodb/arangodb-adapter.spec.ts
@@ -53,7 +53,7 @@ describe('ArangoDBAdapter', () => {
             await adapter.updateSchema(model);
 
             const indices = await db.collection('deliveries').indexes();
-            expect(indices.map(index => ({
+            expect(indices.map((index: any) => ({
                 fields: index.fields,
                 sparse: index.sparse,
                 type: index.type,
@@ -94,7 +94,7 @@ describe('ArangoDBAdapter', () => {
             ]);
 
             const indicesOnOtherCollection = await db.collection('second').indexes();
-            expect(indicesOnOtherCollection.map(index => ({
+            expect(indicesOnOtherCollection.map((index: any) => ({
                 fields: index.fields,
                 sparse: index.sparse,
                 type: index.type,

--- a/spec/dev/server.ts
+++ b/spec/dev/server.ts
@@ -24,7 +24,7 @@ export async function start() {
         });
     }
 
-    const project = await loadProjectFromDir(path.resolve(__dirname, './model'));
+    const project = await loadProjectFromDir(path.resolve(__dirname, './endress-hauser'));
     const schema = project.createSchema(db);
 
     const logger = globalContext.loggerProvider.getLogger('server');
@@ -34,7 +34,7 @@ export async function start() {
 
     const server = new GraphQLServer({
         schema: schema as any, // yoga declares a direct dependency to @types/graphql and it's 0.13
-        context: () => ({ authRoles: ["allusers", "logistics-reader" ]})
+        context: () => ({ authRoles: ["allusers", "logistics-reader", "system" ]})
     });
     await server.start({port});
     logger.info(`Server started on http://localhost:${port}`);

--- a/spec/init.mocha.ts
+++ b/spec/init.mocha.ts
@@ -1,7 +1,9 @@
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import * as deepEqualInAnyOrder from 'deep-equal-in-any-order';
 
 chai.use(chaiAsPromised);
+chai.use(deepEqualInAnyOrder);
 
 import colors from '../src/utils/colors';
 colors.enabled = true;

--- a/spec/model/implementation/root-entity-type.spec.ts
+++ b/spec/model/implementation/root-entity-type.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { Model, RootEntityType, Severity, TypeKind } from '../../../src/model';
 import {
-    expectMultipleMessagesToInclude, expectSingleErrorToInclude, expectToBeValid, validate
+    expectMultipleMessagesToInclude, expectSingleErrorToInclude, expectSingleMessageToInclude, expectToBeValid, validate
 } from './validation-utils';
 
 describe('RootEntityType', () => {
@@ -179,7 +179,7 @@ describe('RootEntityType', () => {
                 keyFieldName: 'address'
             }, model);
 
-            expectMultipleMessagesToInclude(type, `Only fields of type "String", "Int", and "ID" can be used as key field.`, Severity.Error, 2);
+            expectSingleMessageToInclude(type, `Only fields of type "String", "Int", and "ID" can be used as key field.`, Severity.Error);
         });
 
         it('creates a unique index for it', () => {
@@ -204,11 +204,15 @@ describe('RootEntityType', () => {
                 ]
             }, model);
 
-            expect(type.indices).to.have.lengthOf(2);
-            expect(type.indices[0].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['isShipped']);
+            expect(type.indices).to.have.lengthOf(4);
+            expect(type.indices[0].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['isShipped', 'id']);
             expect(type.indices[0].unique).to.equal(false);
             expect(type.indices[1].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber']);
             expect(type.indices[1].unique).to.equal(true);
+            expect(type.indices[2].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber', 'id']);
+            expect(type.indices[2].unique).to.equal(false);
+            expect(type.indices[3].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['id']);
+            expect(type.indices[3].unique).to.equal(false);
         });
 
         it('does not add a unique index if it already exists', () => {
@@ -230,9 +234,13 @@ describe('RootEntityType', () => {
                 ]
             }, model);
 
-            expect(type.indices).to.have.lengthOf(1);
+            expect(type.indices).to.have.lengthOf(3);
             expect(type.indices[0].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber']);
             expect(type.indices[0].unique).to.equal(true);
+            expect(type.indices[1].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber', 'id']);
+            expect(type.indices[1].unique).to.equal(false);
+            expect(type.indices[2].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['id']);
+            expect(type.indices[2].unique).to.equal(false);
         });
 
         it('adds an index if the existing one is not unique', () => {
@@ -253,11 +261,13 @@ describe('RootEntityType', () => {
                 ]
             }, model);
 
-            expect(type.indices).to.have.lengthOf(2);
+            expect(type.indices).to.have.lengthOf(3);
             expect(type.indices[0].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber']);
-            expect(type.indices[0].unique).to.equal(false);
-            expect(type.indices[1].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber']);
-            expect(type.indices[1].unique).to.equal(true);
+            expect(type.indices[0].unique).to.equal(true);
+            expect(type.indices[1].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['deliveryNumber', 'id']);
+            expect(type.indices[1].unique).to.equal(false);
+            expect(type.indices[2].fields.map(f => f.dotSeparatedPath)).to.deep.equal(['id']);
+            expect(type.indices[2].unique).to.equal(false);
         });
     });
 

--- a/spec/performance/associations.perf.ts
+++ b/spec/performance/associations.perf.ts
@@ -36,7 +36,7 @@ async function setUpPapersAndReaders(environment: TestEnvironment, config: { pap
 
 function testFetchWithAssociations(config: { paperCount: number, userCount: number, associationCount: number }): BenchmarkConfig {
     let env: TestEnvironment;
-    let sampledIDs: number[] = [];
+    let sampledIDs: string[] = [];
     return {
         name: `Fetch one of one root entity with one level deep associations (${config.paperCount} papers, ${config.userCount} users, ${config.associationCount} associations`,
         async beforeAll() {

--- a/spec/performance/crud.perf.ts
+++ b/spec/performance/crud.perf.ts
@@ -32,7 +32,7 @@ function getSelectionSet(config: { onlyFewFields?: boolean }) {
 
 function getOneOfXRootEntities(config: { rootEntitiesInDB: number, documentLength: number, onlyFewFields?: boolean }): BenchmarkConfig {
     let env: TestEnvironment;
-    let sampledIDs: number[] = [];
+    let sampledIDs: string[] = [];
     const sizeFactor = getSizeFactorForJSONLength(config.documentLength);
     return {
         name: `Get ${config.onlyFewFields ? 'two fields of ' : ''} one of ${config.rootEntitiesInDB} root entities of size ${formatBytes(config.documentLength)}`,

--- a/spec/performance/index.ts
+++ b/spec/performance/index.ts
@@ -7,10 +7,10 @@ import {default as QUERY_PIPELINE} from "./query-pipeline.perf";
 import {default as REFERENCES} from "./references.perf";
 
 runBenchmarks([
-    ...CRUD,
+    //...CRUD,
     ...PAGINATION,
-    ...COUNT,
-    ...REFERENCES,
-    ...ASSOCIATIONS,
-    ...QUERY_PIPELINE
+    //...COUNT,
+    //...REFERENCES,
+    //...ASSOCIATIONS,
+    //...QUERY_PIPELINE
 ]);

--- a/spec/performance/index.ts
+++ b/spec/performance/index.ts
@@ -4,11 +4,13 @@ import {default as PAGINATION} from "./pagination.perf";
 import {default as COUNT} from "./count.perf";
 import {default as ASSOCIATIONS} from "./associations.perf";
 import {default as QUERY_PIPELINE} from "./query-pipeline.perf";
+import {default as REFERENCES} from "./references.perf";
 
 runBenchmarks([
     ...CRUD,
     ...PAGINATION,
     ...COUNT,
+    ...REFERENCES,
     ...ASSOCIATIONS,
     ...QUERY_PIPELINE
 ]);

--- a/spec/performance/references.perf.ts
+++ b/spec/performance/references.perf.ts
@@ -1,0 +1,70 @@
+import { BenchmarkConfig, BenchmarkFactories } from './support/async-bench';
+import { takeRandomSample } from '../../src/utils/utils';
+import {
+    addManyPapersWithAQL, addManyUsersWithAQL, aql, createLargePaper, createUser, getRandomPaperIDsWithAQL,
+    initEnvironment, TestEnvironment
+} from './support/helpers';
+
+
+async function setUpPapers(environment: TestEnvironment, config: { startIndex: number, paperCount: number, referenceCountEach: number}) {
+    await environment.getDB().query(aql`
+        FOR i IN ${config.startIndex}..${config.startIndex + config.paperCount - 1}
+        INSERT {
+            key: TO_STRING(i),
+            title: CONCAT("Paper ", i),
+            literatureReferences: (
+                FOR j IN 1..${config.referenceCountEach}
+                LET index = FLOOR(RAND() * ${config.paperCount})
+                RETURN {
+                    paper: TO_STRING(index),
+                    title: CONCAT("Paper ", index)
+                }   
+            )
+        } IN papers`);
+}
+
+function testReferenceLookup(config: { paperCount: number, referenceCountEach: number }): BenchmarkConfig {
+    let env: TestEnvironment;
+    let sampledIDs: string[] = [];
+    return {
+        name: `Set up ${config.paperCount} root entities with ${config.referenceCountEach} references each, then fetch a random root entity with all its references`,
+        async beforeAll() {
+            env = await initEnvironment();
+            await setUpPapers(env, {...config, startIndex: 0, paperCount: 1});
+            await setUpPapers(env, {...config, startIndex: 1, paperCount: config.paperCount - 1});
+        },
+
+        async before({count}) {
+            sampledIDs = await getRandomPaperIDsWithAQL(env, count);
+        },
+
+        async fn() {
+            const id = takeRandomSample(sampledIDs);
+            const result = await env.exec(`
+            query($id: ID!) { 
+                Paper(id: $id) { 
+                    id
+                    literatureReferences {
+                        title
+                        paper {
+                            key
+                            title
+                        }
+                    }
+                }
+            }`, {
+                id
+            });
+            if (result.Paper.id != id) {
+                throw new Error(`Unexpected result: ${JSON.stringify(result)}`);
+            }
+        }
+    };
+}
+
+const benchmarks: BenchmarkFactories = [
+    () => testReferenceLookup({paperCount: 1000, referenceCountEach: 50}),
+    () => testReferenceLookup({paperCount: 100000, referenceCountEach: 50})
+];
+
+export default benchmarks;

--- a/spec/performance/support/helpers.ts
+++ b/spec/performance/support/helpers.ts
@@ -38,7 +38,7 @@ export async function initEnvironment(): Promise<TestEnvironment> {
 
     return {
         getDB() {
-            return new Database(dbConfig)
+            return new Database(dbConfig).useDatabase(dbConfig.databaseName)
         },
         async exec(gql, variables) {
             const res = await graphql(schema, gql, {} /* root */, {authRoles: ['admin']}, variables);
@@ -98,10 +98,10 @@ export async function addManyUsersWithAQL(environment: TestEnvironment, count: n
     await environment.getDB().query(aql`FOR i IN 1..${count} INSERT ${userData} IN users`);
 }
 
-export async function getRandomPaperIDsWithAQL(environment: TestEnvironment, count: number): Promise<number[]> {
+export async function getRandomPaperIDsWithAQL(environment: TestEnvironment, count: number): Promise<string[]> {
     const cursor = await environment.getDB().query(aql`FOR node IN papers SORT RAND() LIMIT ${count} RETURN { id: node._key }`);
     const docs = await cursor.all();
-    return docs.map(doc => doc.id);
+    return docs.map((doc: any) => doc.id);
 }
 
 export function formatBytes(bytes: number): string {

--- a/spec/regression/initialization.ts
+++ b/spec/regression/initialization.ts
@@ -1,4 +1,4 @@
-import { Database } from 'arangojs';
+import { Database, DocumentCollection, EdgeCollection } from 'arangojs';
 import * as fs from 'fs';
 import { ExecutionResult, graphql, GraphQLSchema } from 'graphql';
 import { ArangoDBConfig } from '../../src/database/arangodb/arangodb-adapter';
@@ -14,7 +14,7 @@ export async function createTempDatabase(): Promise<ArangoDBConfig> {
     const dbs = await db.listDatabases();
     if (dbs.indexOf(DATABASE_NAME) >= 0) {
         db.useDatabase(DATABASE_NAME);
-        const colls = await db.collections(true);
+        const colls = (await db.collections(true)) as (DocumentCollection | EdgeCollection)[];
         await Promise.all(colls.map(coll => coll.drop()));
     } else {
         await db.createDatabase(DATABASE_NAME);

--- a/spec/regression/logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/logistics/tests/field-permission-denied.result.json
@@ -106,6 +106,19 @@
         "message": "AuthorizationError: Not authorized to read Forwarder objects",
         "locations": [
           {
+            "line": 42,
+            "column": 9
+          }
+        ],
+        "path": [
+          "_allForwardersMeta",
+          "count"
+        ]
+      },
+      {
+        "message": "AuthorizationError: Not authorized to read Forwarder objects",
+        "locations": [
+          {
             "line": 37,
             "column": 5
           }
@@ -113,21 +126,14 @@
         "path": [
           "allForwarders"
         ]
-      },
-      {
-        "message": "AuthorizationError: Not authorized to read Forwarder objects",
-        "locations": [
-          {
-            "line": 41,
-            "column": 5
-          }
-        ],
-        "path": [
-          "_allForwardersMeta"
-        ]
       }
     ],
-    "data": null
+    "data": {
+      "allForwarders": null,
+      "_allForwardersMeta": {
+        "count": null
+      }
+    }
   },
   "filter": {
     "errors": [

--- a/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
@@ -138,18 +138,24 @@
         "message": "AuthorizationError: Not authorized to read Forwarder objects",
         "locations": [
           {
-            "line": 52,
-            "column": 9
+            "line": 53,
+            "column": 13
           }
         ],
         "path": [
           "logistics",
-          "_allForwardersMeta"
+          "_allForwardersMeta",
+          "count"
         ]
       }
     ],
     "data": {
-      "logistics": null
+      "logistics": {
+        "allForwarders": null,
+        "_allForwardersMeta": {
+          "count": null
+        }
+      }
     }
   },
   "filter": {

--- a/spec/regression/papers/model/paper.graphqls
+++ b/spec/regression/papers/model/paper.graphqls
@@ -9,7 +9,7 @@ enum Category {
 "A scientific paper"
 type Paper @rootEntity @roles(readWrite: ["admin"]) {
     key: String @key # need a key field for the reference
-    title: String
+    title: String @index # for pagination performance test
     "The date this paper has been published in a scientific journal or conference"
     publishDate: LocalDate
     isPublished: Boolean

--- a/spec/regression/papers/tests/sort-and-paginate.graphql
+++ b/spec/regression/papers/tests/sort-and-paginate.graphql
@@ -1,19 +1,19 @@
 fragment PapersPage on Paper {
-    #count
-            title
+    title
+    _cursor
 }
 
 query {
     page1: allPapers(orderBy: title_ASC, first: 2) {
         ...PapersPage
     }
-    page2: allPapers(orderBy: title_ASC, first: 2, after: "{\"id\":\"xxx\",\"title\":\"Object-oriented modeling and design\"}") {
+    page2: allPapers(orderBy: title_ASC, first: 2, after: "{\"id\":\"@{ids/Paper/1}\",\"title\":\"Object-oriented modeling and design\"}") {
         ...PapersPage
     }
     page1Desc: allPapers(orderBy: title_DESC, first: 2) {
         ...PapersPage
     }
-    page2Desc: allPapers(orderBy: title_DESC, first: 2, after: "{\"id\":\"xxx\",\"title\":\"Unified modeling language reference manual, the\"}") {
+    page2Desc: allPapers(orderBy: title_DESC, first: 2, after: "{\"id\":\"@{ids/Paper/2}\",\"title\":\"Unified modeling language reference manual, the\"}") {
         ...PapersPage
     }
     emptyPage: allPapers(orderBy: title_ASC, first: 0) {

--- a/spec/regression/papers/tests/sort-and-paginate.result.json
+++ b/spec/regression/papers/tests/sort-and-paginate.result.json
@@ -2,33 +2,41 @@
   "data": {
     "page1": [
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/4}\",\"title\":\"Brewer's conjecture and the feasibility of consistent, available, partition-tolerant web services\"}",
         "title": "Brewer's conjecture and the feasibility of consistent, available, partition-tolerant web services"
       },
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/1}\",\"title\":\"Object-oriented modeling and design\"}",
         "title": "Object-oriented modeling and design"
       }
     ],
     "page2": [
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/5}\",\"title\":\"Scalable SQL and NoSQL data stores\"}",
         "title": "Scalable SQL and NoSQL data stores"
       },
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/2}\",\"title\":\"Unified modeling language reference manual, the\"}",
         "title": "Unified modeling language reference manual, the"
       }
     ],
     "page1Desc": [
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/3}\",\"title\":\"Will NoSQL databases live up to their promise?\"}",
         "title": "Will NoSQL databases live up to their promise?"
       },
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/2}\",\"title\":\"Unified modeling language reference manual, the\"}",
         "title": "Unified modeling language reference manual, the"
       }
     ],
     "page2Desc": [
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/5}\",\"title\":\"Scalable SQL and NoSQL data stores\"}",
         "title": "Scalable SQL and NoSQL data stores"
       },
       {
+        "_cursor": "{\"id\":\"@{ids/Paper/1}\",\"title\":\"Object-oriented modeling and design\"}",
         "title": "Object-oriented modeling and design"
       }
     ],

--- a/spec/schema/ast-validation-modules/key-field-validator.spec.ts
+++ b/spec/schema/ast-validation-modules/key-field-validator.spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { expectSingleErrorToInclude } from '../../model/implementation/validation-utils';
 import {
     assertValidatorAccepts, assertValidatorAcceptsAndDoesNotWarn, assertValidatorRejects, assertValidatorWarns, validate
 } from './helpers';
@@ -18,7 +19,7 @@ describe('key field validator', () => {
     });
 
     it('finds bad type usage', () => {
-        const validationResult = validate(`
+        assertValidatorRejects(`
             type Stuff @rootEntity {
                 foo: String
                 bar: Bar @key
@@ -26,9 +27,7 @@ describe('key field validator', () => {
             type Bar @valueObject {
                 count: Int
             }
-        `);
-        expect(validationResult.hasErrors()).to.be.true;
-        expect(validationResult.getErrors().length, validationResult.toString()).to.equal(2);
+        `, `Only fields of type "String", "Int", and "ID" can be used as key field.`);
     });
 
     it('finds bad list type usage', () => {
@@ -51,16 +50,12 @@ describe('key field validator', () => {
     });
 
     it('disallows keys on fields which are not String or Int', () => {
-        const validationResult = validate(`
+        assertValidatorRejects(`
             type Stuff @rootEntity {
                 foo: String
                 bar: JSON @key
             }
-        `);
-        expect(validationResult.hasErrors()).to.be.true;
-        expect(validationResult.getErrors().length, validationResult.toString()).to.equal(2);
-        const message = validationResult.getErrors().find(m => m.message.indexOf('Only fields of type "String", "Int", and "ID" can be used as key field.')>=0);
-        expect(message).to.not.be.undefined;
+        `, 'Only fields of type "String", "Int", and "ID" can be used as key field.');
     });
 
     it('accepts correct key usage', () => {

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -327,6 +327,7 @@ register(CountQueryNode, (node, context) => {
     // because it avoids building the whole collection temporarily in memory
     // however, https://docs.arangodb.com/3.2/AQL/Examples/Counting.html does not really mention this case, so we
     // should evaluate it again
+    // note that ArangoDB's inline-subqueries rule optimizes for the case where listNode is a TransformList again.
     const itemVar = aql.variable('item');
     const countVar = aql.variable('count');
     return aqlExt.parenthesizeObject(

--- a/src/database/index-helpers.ts
+++ b/src/database/index-helpers.ts
@@ -1,5 +1,6 @@
-import { compact, flatMap } from '../utils/utils';
 import { IndexField, Model, RootEntityType } from '../model';
+import { ID_FIELD } from '../schema/constants';
+import { compact, flatMap } from '../utils/utils';
 
 export interface IndexDefinition {
     id?: string,
@@ -13,22 +14,57 @@ function indexDefinitionsEqual(a: IndexDefinition, b: IndexDefinition) {
     return a.rootEntity === b.rootEntity && a.fields.join('|') === b.fields.join('|') && a.unique === b.unique && a.sparse === b.sparse;
 }
 
-export function getRequiredIndicesFromModel(model: Model): ReadonlyArray<IndexDefinition> {
-    return flatMap(model.rootEntityTypes, rootEntity => {
-        return rootEntity.indices.map(index => ({
-            rootEntity,
-            id: index.id,
-            fields: index.fields.map(getArangoFieldPath),
-            unique: index.unique,
-
-            // sic! unique indices should always be sparse so that more than one NULL value is allowed
-            // non-unique indices should not be sparse so that filter: { something: null } can use the index
-            sparse: index.unique
-        }));
-    });
+export function getRequiredIndicesFromModel(model: Model, { shouldUseWorkaroundForSparseIndices = false }: { shouldUseWorkaroundForSparseIndices?: boolean } = {}): ReadonlyArray<IndexDefinition> {
+    return flatMap(model.rootEntityTypes, rootEntity => getIndicesForRootEntity(rootEntity, { shouldUseWorkaroundForSparseIndices }));
 }
 
-export function calculateRequiredIndexOperations(existingIndices: ReadonlyArray<IndexDefinition>, requiredIndices: ReadonlyArray<IndexDefinition>):{
+function getIndicesForRootEntity(rootEntity: RootEntityType, options: { shouldUseWorkaroundForSparseIndices: boolean }): ReadonlyArray<IndexDefinition> {
+    const indices: IndexDefinition[] = rootEntity.indices.map(index => ({
+        rootEntity,
+        id: index.id,
+        fields: index.fields.map(getArangoFieldPath),
+        unique: index.unique,
+
+        // sic! unique indices should always be sparse so that more than one NULL value is allowed
+        // non-unique indices should not be sparse so that filter: { something: null } can use the index
+        sparse: index.unique
+    }));
+
+    if (options.shouldUseWorkaroundForSparseIndices && rootEntity.keyField) {
+        // add a non-sparse index to be used for @reference lookups if arangodb does not support dynamic usage of sparse
+        // indices yet
+        const newIndex: IndexDefinition = {
+            rootEntity,
+            fields: [rootEntity.keyField.name],
+
+            sparse: false,
+            unique: false
+        };
+
+        if (!indices.some(index => indexStartsWith(index, newIndex))) {
+            indices.push(newIndex);
+        }
+    }
+
+    return indices;
+}
+
+function indexStartsWith(index: IndexDefinition, prefix: IndexDefinition) {
+    if (index.sparse !== prefix.sparse || index.unique !== prefix.unique || index.rootEntity !== prefix.rootEntity) {
+        return false;
+    }
+    if (index.fields.length < prefix.fields.length) {
+        return false;
+    }
+    for (let i = 0; i < prefix.fields.length; i++) {
+        if (index.fields[i] !== prefix.fields[i]) {
+            return false;
+        }
+    }
+    return true;
+}
+
+export function calculateRequiredIndexOperations(existingIndices: ReadonlyArray<IndexDefinition>, requiredIndices: ReadonlyArray<IndexDefinition>): {
     indicesToDelete: ReadonlyArray<IndexDefinition>,
     indicesToCreate: ReadonlyArray<IndexDefinition>
 } {
@@ -41,13 +77,18 @@ export function calculateRequiredIndexOperations(existingIndices: ReadonlyArray<
         }
         return requiredIndex;
     }));
-    return {indicesToDelete, indicesToCreate};
+    return { indicesToDelete, indicesToCreate };
 }
 
 /**
  * Gets the field path of an index prepared for Arango, adding [*] suffix to spread list items on list types
  */
 function getArangoFieldPath(indexField: IndexField): string {
+    if (indexField.declaringType.isRootEntityType && indexField.path.length === 1 && indexField.path[0] === ID_FIELD) {
+        // translate to arangodb's id field
+        return '_key';
+    }
+
     return (indexField.fieldsInPath || [])
         .map(field => field.isList ? `${field.name}[*]` : field.name)
         .join('.');

--- a/src/model/implementation/child-entity-type.ts
+++ b/src/model/implementation/child-entity-type.ts
@@ -1,3 +1,5 @@
+import { ID_FIELD } from '../../schema/constants';
+import { Field } from './field';
 import { ObjectTypeBase } from './object-type-base';
 import { ChildEntityTypeConfig, FieldConfig, TypeKind } from '../config';
 import { Model } from './model';
@@ -5,6 +7,13 @@ import { Model } from './model';
 export class ChildEntityType extends ObjectTypeBase {
     constructor(input: ChildEntityTypeConfig, model: Model) {
         super(input, model, systemFieldInputs);
+    }
+
+    /**
+     * Gets a field that is guaranteed to be unique, to be used for absolute order
+     */
+    get discriminatorField(): Field {
+        return this.getFieldOrThrow(ID_FIELD);
     }
 
     readonly kind: TypeKind.CHILD_ENTITY = TypeKind.CHILD_ENTITY;

--- a/src/model/implementation/indices.ts
+++ b/src/model/implementation/indices.ts
@@ -100,6 +100,18 @@ export class Index implements ModelComponent {
         this.astNode = input.astNode;
     }
 
+    equals(other: Index) {
+        if (this.id !== other.id || this.unique !== other.unique || this.fields.length !== other.fields.length) {
+            return false;
+        }
+        for (let i = 0; i < this.fields.length; i++) {
+            if (this.fields[i].dotSeparatedPath !== other.fields[i].dotSeparatedPath) {
+                return false;
+            }
+        }
+        return true;
+    }
+
     validate(context: ValidationContext) {
         if (!this.fields.length) {
             context.addMessage(ValidationMessage.error(`An index must specify at least one field.`, this.astNode))

--- a/src/schema-generation/field-nodes.ts
+++ b/src/schema-generation/field-nodes.ts
@@ -5,6 +5,17 @@ import { ID_FIELD } from '../schema/constants';
 import { and } from './filter-input-types/constants';
 
 export function createFieldNode(field: Field, sourceNode: QueryNode): QueryNode {
+    // make use of the fact that field access on non-objects is NULL, so that type checks for OBJECT are redundant
+    // this e.g. reverses the effect of the isEntityExtensionType check below
+    // this is important for filter/orderBy which do not work if there is a conditional
+    if (sourceNode instanceof ConditionalQueryNode &&
+        sourceNode.condition instanceof TypeCheckQueryNode &&
+        sourceNode.condition.type === BasicType.OBJECT &&
+        sourceNode.expr1 === sourceNode.condition.valueNode
+    ) {
+        sourceNode = sourceNode.expr1;
+    }
+
     if (field.isList) {
         if (field.isRelation) {
             return createToNRelationNode(field, sourceNode);

--- a/src/schema-generation/output-type-generator.ts
+++ b/src/schema-generation/output-type-generator.ts
@@ -135,6 +135,7 @@ export class OutputTypeGenerator {
         const plainField: QueryNodeField = {
             name: getMetaFieldName(field.name),
             type: new QueryNodeNonNullType(metaType),
+            skipNullCheck: true, // meta fields should never be null
             description: field.description,
             resolve: (sourceNode) => createFieldNode(field, sourceNode)
         };

--- a/src/schema-generation/query-node-object-type/definition.ts
+++ b/src/schema-generation/query-node-object-type/definition.ts
@@ -20,6 +20,14 @@ export interface QueryNodeField {
      * Indicates whether this field should be resolved in the user-specified sequence among other serial fields
      */
     isSerial?: boolean
+
+    /**
+     * If set to `true`, the resolved value is not checked against NULL
+     *
+     * Normally, fields whose type is an object type evaluate to NULL if the source value is NULL. If this flag is set,
+     * NULL is passed to the field resolvers within.
+     */
+    skipNullCheck?: boolean
 }
 
 export interface QueryNodeObjectType {

--- a/src/schema-generation/query-node-object-type/query-node-generator.ts
+++ b/src/schema-generation/query-node-object-type/query-node-generator.ts
@@ -1,9 +1,5 @@
 import { FieldRequest, FieldSelection } from '../../graphql/query-distiller';
-import {
-    BasicType, ConditionalQueryNode, NullQueryNode, ObjectQueryNode, PreExecQueryParms, PropertySpecification,
-    QueryNode, TransformListQueryNode, TypeCheckQueryNode, VariableAssignmentQueryNode, VariableQueryNode,
-    WithPreExecutionQueryNode
-} from '../../query-tree';
+import { BasicType, ConditionalQueryNode, NullQueryNode, ObjectQueryNode, PreExecQueryParms, PropertySpecification, QueryNode, TransformListQueryNode, TypeCheckQueryNode, VariableAssignmentQueryNode, VariableQueryNode, WithPreExecutionQueryNode } from '../../query-tree';
 import { decapitalize } from '../../utils/utils';
 import { QueryNodeField, QueryNodeObjectType } from './definition';
 import { extractQueryTreeObjectType, isListType, resolveThunk } from './utils';
@@ -81,11 +77,14 @@ function buildFieldQueryNode0(sourceNode: QueryNode, field: QueryNodeField, fiel
         // This is no longer necessary because createFieldNode() already does this where necessary (only for simple field lookups)
         // All other code should return lists where lists are expected
         return buildTransformListQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
+    }
+
+    // object
+    if (field.skipNullCheck) {
+        return buildObjectQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
     } else {
         // This is necessary because we want to return `null` if a field is null, and not pass `null` through as
         // `source`, just as the graphql engine would do, too.
-        // It currently also treats non-objects as `null` (just because it's free), but we may move this to
-        // createFieldNode() later.
         return buildConditionalObjectQueryNode(fieldQueryNode, queryTreeObjectType, fieldRequest.selectionSet, newFieldRequestStack);
     }
 }

--- a/src/schema-generation/query-type-generator.ts
+++ b/src/schema-generation/query-type-generator.ts
@@ -86,6 +86,10 @@ export class QueryTypeGenerator {
             name: getMetaFieldName(getAllEntitiesFieldName(rootEntityType.name)),
             type: new QueryNodeNonNullType(metaType),
             description: rootEntityType.description,
+            // meta fields should never be null. Also, this is crucial for performance. Without it, we would introduce
+            // an unnecessary variable with the collection contents (which is slow) and we would to an equality check of
+            // a collection against NULL which is deadly (v8 evaluation)
+            skipNullCheck: true,
             resolve: () => this.getAllRootEntitiesNode(rootEntityType)
         });
         return this.filterAugmentation.augment(fieldConfig, rootEntityType);

--- a/src/schema-generation/utils/filtering.ts
+++ b/src/schema-generation/utils/filtering.ts
@@ -1,13 +1,21 @@
 import { Type } from '../../model';
-import { QueryNode, TransformListQueryNode, VariableQueryNode } from '../../query-tree';
+import { ConstBoolQueryNode, QueryNode, TransformListQueryNode, VariableQueryNode } from '../../query-tree';
+import { simplifyBooleans } from '../../query-tree/utils';
 import { FILTER_ARG } from '../../schema/constants';
 import { decapitalize } from '../../utils/utils';
 import { FilterObjectType } from '../filter-input-types';
 
-export function buildFilteredListNode(listNode: QueryNode, args: {[name: string]: any}, filterType: FilterObjectType, itemType: Type) {
+export function buildFilteredListNode(listNode: QueryNode, args: { [name: string]: any }, filterType: FilterObjectType, itemType: Type) {
     const filterValue = args[FILTER_ARG] || {};
     const itemVariable = new VariableQueryNode(decapitalize(itemType.name));
-    const filterNode = filterType.getFilterNode(itemVariable, filterValue);
+    // simplification is important for the shortcut with check for TRUE below in the case of e.g. { AND: [] }
+    const filterNode = simplifyBooleans(filterType.getFilterNode(itemVariable, filterValue));
+
+    // avoid unnecessary TransformLists especially for count queries, so that it can be optimized to LENGTH(collection)
+    if (filterNode === ConstBoolQueryNode.TRUE) {
+        return listNode;
+    }
+
     return new TransformListQueryNode({
         listNode,
         itemVariable,

--- a/src/schema-generation/utils/pagination.ts
+++ b/src/schema-generation/utils/pagination.ts
@@ -1,5 +1,5 @@
 import { OrderDirection } from '../../query-tree';
-import { FIRST_ARG, ID_FIELD, ORDER_BY_ARG } from '../../schema/constants';
+import { FIRST_ARG, ORDER_BY_ARG } from '../../schema/constants';
 import { OrderByEnumType, OrderByEnumValue } from '../order-by-enum-generator';
 
 export function getOrderByValues(args: any, orderByType: OrderByEnumType, {forceAbsoluteOrder = false}: { readonly forceAbsoluteOrder?: boolean } = {}): ReadonlyArray<OrderByEnumValue> {
@@ -9,12 +9,21 @@ export function getOrderByValues(args: any, orderByType: OrderByEnumType, {force
     // if first is present, we are paginating, which only works when there is an absolute order
     // To achieve this, we add the 'id' as sort clause
     // Doesn't work on value objects though
-    const needsID = forceAbsoluteOrder || FIRST_ARG in args;
-    if (needsID && (orderByType.objectType.isChildEntityType || orderByType.objectType.isRootEntityType) && !valueNames.includes(ID_FIELD)) {
-        return [
-            ...values,
-            new OrderByEnumValue([orderByType.objectType.getFieldOrThrow(ID_FIELD)], OrderDirection.ASCENDING)
-        ];
+    const needsAbsoluteOrdering = forceAbsoluteOrder || FIRST_ARG in args;
+    if (needsAbsoluteOrdering && (orderByType.objectType.isChildEntityType || orderByType.objectType.isRootEntityType)) {
+        const discriminatorField = orderByType.objectType.discriminatorField;
+        // indices only work if all directions are equal. So if all are descending, add the discriminator field
+        // descending, too - otherwise, it does not matter, so we default to ascending. If there are no values, default
+        // to ascending, too.
+        let direction = (values.length > 0 && values.every(value => value.direction === OrderDirection.DESCENDING)) ?
+            OrderDirection.DESCENDING : OrderDirection.ASCENDING;
+
+        if (!values.some(v => v.path.length === 1 && v.path[0] === discriminatorField)) {
+            return [
+                ...values,
+                new OrderByEnumValue([discriminatorField], direction)
+            ];
+        }
     }
     return values;
 }

--- a/src/typings/deep-equal-in-any-order.d.ts
+++ b/src/typings/deep-equal-in-any-order.d.ts
@@ -1,0 +1,7 @@
+declare module 'deep-equal-in-any-order';
+
+declare namespace Chai {
+    interface Deep {
+        equalInAnyOrder: Equal;
+    }
+}

--- a/tools/setup-arangodb.sh
+++ b/tools/setup-arangodb.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# source: https://download.arangodb.com/travisCI/setup_arangodb_3.2.11.sh
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+cd $DIR
+
+VERSION=3.2.11
+NAME=ArangoDB-$VERSION
+
+if [ ! -d "$DIR/$NAME" ]; then
+  # download ArangoDB
+  echo "curl -L -o $NAME.tar.gz https://www.arangodb.com/repositories/travisCI/$NAME.tar.gz"
+  curl -L -o $NAME.tar.gz https://www.arangodb.com/repositories/travisCI/$NAME.tar.gz
+  echo "tar zxf $NAME.tar.gz"
+  tar zvxf $NAME.tar.gz
+fi
+
+ARCH=$(arch)
+PID=$(echo $PPID)
+TMP_DIR="/tmp/arangodb.$PID"
+PID_FILE="/tmp/arangodb.$PID.pid"
+ARANGODB_DIR="$DIR/$NAME"
+ARANGOD="${ARANGODB_DIR}/bin/arangod_x86_64"
+
+# create database directory
+mkdir ${TMP_DIR}
+
+echo "Starting ArangoDB '${ARANGOD}'"
+
+${ARANGOD} \
+    --database.directory ${TMP_DIR} \
+    --configuration none \
+    --server.endpoint tcp://127.0.0.1:8529 \
+    --javascript.app-path ${ARANGODB_DIR}/js/apps \
+    --javascript.startup-directory ${ARANGODB_DIR}/js \
+    --database.maximal-journal-size 1048576 \
+    --server.authentication false &
+
+sleep 2
+
+echo "Check for arangod process"
+process=$(ps auxww | grep "bin/arangod" | grep -v grep)
+
+if [ "x$process" == "x" ]; then
+  echo "no 'arangod' process found"
+  echo "ARCH = $ARCH"
+  exit 1
+fi
+
+echo "Waiting until ArangoDB is ready on port 8529"
+
+n=0
+# timeout value for startup
+timeout=60 
+while [[ (-z `curl -H 'Authorization: Basic cm9vdDo=' -s 'http://127.0.0.1:8529/_api/version' `) && (n -lt timeout) ]] ; do
+  echo -n "."
+  sleep 1s
+  n=$[$n+1]
+done
+
+if [[ n -eq timeout ]];
+then
+    echo "Could not start ArangoDB. Timeout reached."
+    exit 1
+fi
+
+
+echo "ArangoDB is up"


### PR DESCRIPTION
# count

Previously, we treated the collection as array which is highly
inefficient. This was a regression from version 0.5.

before:

```
[1 / 4] Count all of 1000 root entities...
  7.136ms (±14.37%) per iteration
  37s elapsed (18% for setup) for 4198 iterations in 16 cycles

[2 / 4] Count all of 1000000 root entities...
  5688.454ms (±63.62%) per iteration
  49s elapsed (31% for setup) for 6 iterations in 6 cycles

[3 / 4] Count about half of 1000 root entities...
  14.501ms (±5.17%) per iteration
  31s elapsed (2% for setup) for 2069 iterations in 13 cycles

[4 / 4] Count about half of 1000000 root entities...
  2383.355ms (±27.08%) per iteration
  41s elapsed (30% for setup) for 12 iterations in 7 cycles
```


now:

```
[1 / 4] Count all of 1000 root entities...
5.451ms (±1.82%) per iteration
21s elapsed (3% for setup) for 3710 iterations in 9 cycles

[2 / 4] Count all of 1000000 root entities...
7.426ms (±6.03%) per iteration
40s elapsed (25% for setup) for 4046 iterations in 10 cycles

[3 / 4] Count about half of 1000 root entities...
7.213ms (±1.99%) per iteration
16s elapsed (2% for setup) for 2172 iterations in 7 cycles

[4 / 4] Count about half of 1000000 root entities...
968.006ms (±16.43%) per iteration
43s elapsed (30% for setup) for 31 iterations in 14 cycles
```


# @reference lookup

Currently, we create unique sparse indices on @key fields. However, sparse indices are not usable for reference lookup before arangodb 3.4. For the meantime, this adds a workaround that creates non-sparse non-unique indices for keys.

before:

```
[1 / 2] Set up 1000 root entities with 50 references each, then fetch a random root entity with all its references...
38.231ms (±1.98%) per iteration
14s elapsed (24% for setup) for 286 iterations in 5 cycles

[2 / 2] Set up 100000 root entities with 50 references each, then fetch a random root entity with all its references...
3996.238ms (±5.29%) per iteration
55s elapsed (49% for setup) for 7 iterations in 7 cycles
```

after:

```
[1 / 1] Set up 1000 root entities with 50 references each, then fetch a random root entity with all its references...
17.260ms (±2.46%) per iteration
32s elapsed (5% for setup) for 1741 iterations in 13 cycles

[1 / 1] Set up 100000 root entities with 50 references each, then fetch a random root entity with all its references...
14.565ms (±3.09%) per iteration
75s elapsed (60% for setup) for 2053 iterations in 16 cycles
```