### PR TITLE
Add option to limit root-entity traversal for orderBy

### DIFF
--- a/spec/schema-generation/order-by-enum-generator.spec.ts
+++ b/spec/schema-generation/order-by-enum-generator.spec.ts
@@ -3,9 +3,8 @@ import { Model, TypeKind } from '../../src/model';
 import { OrderByEnumGenerator } from '../../src/schema-generation/order-by-enum-generator';
 
 describe('OrderByEnumGenerator', () => {
-    const generator = new OrderByEnumGenerator();
-
     it('includes scalar fields', () => {
+        const generator = new OrderByEnumGenerator();
         const model = new Model({
             types: [
                 {
@@ -34,6 +33,7 @@ describe('OrderByEnumGenerator', () => {
     });
 
     it('does not include list fields', () => {
+        const generator = new OrderByEnumGenerator();
         const model = new Model({
             types: [
                 {
@@ -57,6 +57,115 @@ describe('OrderByEnumGenerator', () => {
             'createdAt_DESC',
             'updatedAt_ASC',
             'updatedAt_DESC'
+        ]);
+    });
+
+    const shipmentDeliveryModel = new Model({
+        types: [
+            {
+                name: 'Delivery',
+                kind: TypeKind.ROOT_ENTITY,
+                fields: [
+                    {
+                        name: 'dangerousGoodsInfo',
+                        typeName: 'DangerousGoodsInfo'
+                    },
+                    {
+                        name: 'shipment',
+                        typeName: 'Shipment',
+                        isRelation: true
+                    }
+                ]
+            },
+            {
+                name: 'DangerousGoodsInfo',
+                kind: TypeKind.ENTITY_EXTENSION,
+                fields: [
+                    {
+                        name: 'isDangerousGoods',
+                        typeName: 'Boolean'
+                    }
+                ]
+            },
+            {
+                name: 'Shipment',
+                kind: TypeKind.ROOT_ENTITY,
+                fields: [
+                    {
+                        name: 'delivery',
+                        typeName: 'Delivery',
+                        isRelation: true,
+                        inverseOfFieldName: 'shipment'
+                    }
+                ]
+            }
+        ]
+    });
+
+    const deliveryType = shipmentDeliveryModel.getObjectTypeOrThrow('Delivery');
+
+    it('includes root entity traversal fields', () => {
+        const generator = new OrderByEnumGenerator();
+        const enumType = generator.generate(deliveryType);
+        expect(enumType.values.map(v => v.name)).to.deep.equal([
+            'id_ASC',
+            'id_DESC',
+            'createdAt_ASC',
+            'createdAt_DESC',
+            'updatedAt_ASC',
+            'updatedAt_DESC',
+            'dangerousGoodsInfo_isDangerousGoods_ASC',
+            'dangerousGoodsInfo_isDangerousGoods_DESC',
+            'shipment_id_ASC',
+            'shipment_id_DESC',
+            'shipment_createdAt_ASC',
+            'shipment_createdAt_DESC',
+            'shipment_updatedAt_ASC',
+            'shipment_updatedAt_DESC',
+            'shipment_delivery_id_ASC',
+            'shipment_delivery_id_DESC',
+            'shipment_delivery_createdAt_ASC',
+            'shipment_delivery_createdAt_DESC',
+            'shipment_delivery_updatedAt_ASC',
+            'shipment_delivery_updatedAt_DESC',
+            'shipment_delivery_dangerousGoodsInfo_isDangerousGoods_ASC',
+            'shipment_delivery_dangerousGoodsInfo_isDangerousGoods_DESC'
+        ]);
+    });
+
+    it('cuts off root entity traversal fields if specified', () => {
+        const generator = new OrderByEnumGenerator({ maxRootEntityDepth: 1 });
+        const enumType = generator.generate(deliveryType);
+        expect(enumType.values.map(v => v.name)).to.deep.equal([
+            'id_ASC',
+            'id_DESC',
+            'createdAt_ASC',
+            'createdAt_DESC',
+            'updatedAt_ASC',
+            'updatedAt_DESC',
+            'dangerousGoodsInfo_isDangerousGoods_ASC',
+            'dangerousGoodsInfo_isDangerousGoods_DESC',
+            'shipment_id_ASC',
+            'shipment_id_DESC',
+            'shipment_createdAt_ASC',
+            'shipment_createdAt_DESC',
+            'shipment_updatedAt_ASC',
+            'shipment_updatedAt_DESC',
+        ]);
+    });
+
+    it('does not generate root entity traversal fields if specified as 0', () => {
+        const generator = new OrderByEnumGenerator({ maxRootEntityDepth: 0 });
+        const enumType = generator.generate(deliveryType);
+        expect(enumType.values.map(v => v.name)).to.deep.equal([
+            'id_ASC',
+            'id_DESC',
+            'createdAt_ASC',
+            'createdAt_DESC',
+            'updatedAt_ASC',
+            'updatedAt_DESC',
+            'dangerousGoodsInfo_isDangerousGoods_ASC',
+            'dangerousGoodsInfo_isDangerousGoods_DESC'
         ]);
     });
 });

--- a/src/config/interfaces.ts
+++ b/src/config/interfaces.ts
@@ -16,10 +16,19 @@ export interface RequestProfile extends RequestContext {
     readonly plan?: ExecutionPlan;
 }
 
+export interface SchemaOptions {
+    /**
+     * The maximum depth root entities can be traversed through for orderBy values
+     */
+    readonly maxOrderByRootEntityDepth?: number;
+}
+
 export interface ProjectOptions {
     readonly loggerProvider?: LoggerProvider;
     readonly profileConsumer?: (profile: RequestProfile) => void;
     readonly getExecutionOptions?: (args: ExecutionOptionsCallbackArgs) => ExecutionOptions;
+
+    readonly schemaOptions?: SchemaOptions
 
     /**
      * Is called when an operation execution throws an error

--- a/src/database/arangodb/schema-migration/index-helpers.ts
+++ b/src/database/arangodb/schema-migration/index-helpers.ts
@@ -1,3 +1,4 @@
+import { GraphQLInt } from 'graphql';
 import { IndexField, Model, RootEntityType } from '../../../model';
 import { ID_FIELD } from '../../../schema/constants';
 import { compact, flatMap } from '../../../utils/utils';

--- a/src/project/project.ts
+++ b/src/project/project.ts
@@ -42,7 +42,8 @@ export class Project {
             loggerProvider: config.loggerProvider,
             profileConsumer: config.profileConsumer,
             getExecutionOptions: config.getExecutionOptions,
-            processError: config.processError
+            processError: config.processError,
+            schemaOptions: config.schemaOptions
         };
     }
 

--- a/src/schema-generation/root-types-generator.ts
+++ b/src/schema-generation/root-types-generator.ts
@@ -1,4 +1,5 @@
 import memorize from 'memorize-decorator';
+import { SchemaOptions } from '../config/interfaces';
 import { Model } from '../model';
 import { CreateInputTypeGenerator } from './create-input-types';
 import { EnumTypeGenerator } from './enum-type-generator';
@@ -11,14 +12,17 @@ import { MutationTypeGenerator } from './mutation-type-generator';
 import { OrderByAndPaginationAugmentation } from './order-by-and-pagination-augmentation';
 import { OrderByEnumGenerator } from './order-by-enum-generator';
 import { OutputTypeGenerator } from './output-type-generator';
-import { QueryNodeObjectType, QueryNodeObjectTypeConverter } from './query-node-object-type';
+import { QueryNodeObjectType } from './query-node-object-type';
 import { QueryTypeGenerator } from './query-type-generator';
 import { UpdateInputTypeGenerator } from './update-input-types';
 
 export class RootTypesGenerator {
+    constructor(private readonly options: SchemaOptions = {}) {
+    }
+
     private readonly enumTypeGenerator = new EnumTypeGenerator();
     private readonly filterTypeGenerator = new FilterTypeGenerator(this.enumTypeGenerator);
-    private readonly orderByEnumGenerator = new OrderByEnumGenerator();
+    private readonly orderByEnumGenerator = new OrderByEnumGenerator({ maxRootEntityDepth: this.options.maxOrderByRootEntityDepth });
     private readonly orderByAugmentation = new OrderByAndPaginationAugmentation(this.orderByEnumGenerator);
     private readonly filterAugmentation = new FilterAugmentation(this.filterTypeGenerator);
     private readonly listAugmentation = new ListAugmentation(this.filterAugmentation, this.orderByAugmentation);

--- a/src/schema-generation/schema-generator.ts
+++ b/src/schema-generation/schema-generator.ts
@@ -7,7 +7,7 @@ import { QueryNodeObjectTypeConverter } from './query-node-object-type';
 import { RootTypesGenerator } from './root-types-generator';
 
 export class SchemaGenerator {
-    private readonly rootTypesGenerator = new RootTypesGenerator();
+    private readonly rootTypesGenerator = new RootTypesGenerator(this.context.schemaOptions);
     private readonly queryNodeObjectTypeConverter = new QueryNodeObjectTypeConverter();
     private readonly operationResolver: OperationResolver;
 


### PR DESCRIPTION
This should reduce the size of the GraphQL schema (introspection result,
memory usage of a GraphQLSchema instance, types etc.) drastically in a
large schema with many relations. We might even consider to set this
option to zero in the future because cross-root-entity orders are really
slow.