### PR TITLE
Allow empty string in single-root-entity arguments

### DIFF
--- a/spec/regression/logistics/tests/query-single.graphql
+++ b/spec/regression/logistics/tests/query-single.graphql
@@ -38,6 +38,13 @@ query nullArg {
     }
 }
 
+# empty string counts as specified
+query emptyArg {
+    Delivery(id: "") {
+        deliveryNumber
+    }
+}
+
 query twoNullArgs {
     Delivery(id: null, deliveryNumber: null) {
         deliveryNumber

--- a/spec/regression/logistics/tests/query-single.result.json
+++ b/spec/regression/logistics/tests/query-single.result.json
@@ -75,13 +75,18 @@
       "Delivery": null
     }
   },
+  "emptyArg": {
+    "data": {
+      "Delivery": null
+    }
+  },
   "twoNullArgs": {
     "errors": [
       {
         "message": "Must specify exactly one non-null argument to field \"Delivery\"",
         "locations": [
           {
-            "line": 42,
+            "line": 49,
             "column": 5
           }
         ],

--- a/src/schema-generation/utils/entities-by-unique-field.ts
+++ b/src/schema-generation/utils/entities-by-unique-field.ts
@@ -11,7 +11,7 @@ import { createGraphQLError } from '../graphql-errors';
 import { FieldContext } from '../query-node-object-type';
 
 export function getEntitiesByUniqueFieldQuery(rootEntityType: RootEntityType, args: {[name:string]: any}, context: FieldContext) {
-    const nonNullArgs = objectEntries(args).filter(([key, value]) => value);
+    const nonNullArgs = objectEntries(args).filter(([key, value]) => value != undefined);
     if (nonNullArgs.length !== 1) {
         throw createGraphQLError(`Must specify exactly one non-null argument to field "${rootEntityType.name}"`, context);
     }


### PR DESCRIPTION
There won't be an entity to find, but we should not treat the empty
string as if it were null.