### PR TITLE
Optimize identical field selections into one

### DIFF
--- a/spec/utils/group-by-equivalence.spec.ts
+++ b/spec/utils/group-by-equivalence.spec.ts
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+import { groupByEquivalence } from '../../src/utils/group-by-equivalence';
+
+describe('groupByEquivalence', () => {
+    it('groups correctly', () => {
+        const groups = groupByEquivalence(['a', 'c', 'b', 'A', 'C', 'C'], (a, b) => a.toUpperCase() === b.toUpperCase());
+        expect(groups).to.deep.equal([['a', 'A'], ['c', 'C', 'C'], ['b']]);
+    });
+});

--- a/src/graphql/query-distiller.ts
+++ b/src/graphql/query-distiller.ts
@@ -1,4 +1,5 @@
 import { DocumentNode, FieldNode, FragmentDefinitionNode, getNamedType, GraphQLCompositeType, GraphQLField, GraphQLObjectType, GraphQLOutputType, GraphQLSchema, isCompositeType, OperationDefinitionNode, OperationTypeNode, SelectionNode } from 'graphql';
+import { isEqual } from 'lodash';
 import { blue, cyan, green } from '../utils/colors';
 import { arrayToObject, flatMap, groupArray, indent, INDENTATION } from '../utils/utils';
 import { getArgumentValues } from './argument-values';
@@ -40,6 +41,21 @@ export class FieldRequest {
         return this.field.name;
     }
 
+    equals(other: FieldRequest) {
+        if (this.field !== other.field || this.parentType !== other.parentType || this.schema !== other.schema
+            || this.selectionSet.length !== other.selectionSet.length || !isEqual(this.args, other.args)) {
+            return false;
+        }
+
+        for (let i = 0; i < this.selectionSet.length; i++) {
+            if (!other.selectionSet[i].equals(this.selectionSet[i])) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     public describe(): string {
         const selectionItemsDesc = this.selectionSet
             .map(selection => `${green(JSON.stringify(selection.propertyName))}: ${selection.fieldRequest.describe()}`)
@@ -63,6 +79,10 @@ export class FieldSelection {
     constructor(public readonly propertyName: string,
                 public readonly fieldRequest: FieldRequest) {
 
+    }
+
+    equals(other: FieldSelection) {
+        return this.propertyName === other.propertyName && this.fieldRequest.equals(other.fieldRequest);
     }
 }
 

--- a/src/query-tree/utils/extract-variable-assignments.ts
+++ b/src/query-tree/utils/extract-variable-assignments.ts
@@ -1,7 +1,4 @@
-import {
-    BinaryOperationQueryNode, ConditionalQueryNode, FieldQueryNode, FirstOfListQueryNode, ObjectQueryNode, OrderClause, OrderSpecification,
-    PropertySpecification, QueryNode, RootEntityIDQueryNode, UnaryOperationQueryNode, VariableAssignmentQueryNode
-} from '..';
+import { BinaryOperationQueryNode, ConditionalQueryNode, FieldQueryNode, FirstOfListQueryNode, ObjectQueryNode, OrderClause, OrderSpecification, PropertySpecification, QueryNode, RootEntityIDQueryNode, UnaryOperationQueryNode, VariableAssignmentQueryNode } from '..';
 
 /**
  * Traverses recursively through Unary/Binary operations, extracts all variable definitions and replaces them by their
@@ -27,7 +24,17 @@ export function extractVariableAssignments(node: QueryNode, variableAssignmentsL
         );
     }
     if (node instanceof VariableAssignmentQueryNode) {
-        variableAssignmentsList.push(node);
+        // traverse into the variable value node
+        const newVariableValueNode = extractVariableAssignments(node.variableValueNode, variableAssignmentsList);
+        if (newVariableValueNode === node.variableValueNode) {
+            variableAssignmentsList.push(node);
+        } else {
+            variableAssignmentsList.push(new VariableAssignmentQueryNode({
+                variableNode: node.variableNode,
+                resultNode: node.resultNode,
+                variableValueNode: newVariableValueNode
+            }));
+        }
         return extractVariableAssignments(node.resultNode, variableAssignmentsList);
     }
     if (node instanceof FirstOfListQueryNode) {

--- a/src/schema-generation/meta-type-generator.ts
+++ b/src/schema-generation/meta-type-generator.ts
@@ -19,6 +19,7 @@ export class MetaTypeGenerator {
             name: COUNT_META_FIELD,
             type: GraphQLInt,
             description: 'The number of items in the collection or list, after applying the filter if specified.',
+            isPure: true,
             resolve: listNode => new CountQueryNode(listNode)
         };
     }

--- a/src/schema-generation/output-type-generator.ts
+++ b/src/schema-generation/output-type-generator.ts
@@ -84,6 +84,7 @@ export class OutputTypeGenerator {
         return {
             name: CURSOR_FIELD,
             type: GraphQLString,
+            isPure: true,
             description: `Provides a value that can be supplied to the \`after\` argument for pagination. Depends on the value of the \`orderBy\` argument.`,
             resolve: (source, args, info) => this.getCursorNode(source, info.selectionStack[info.selectionStack.length - 2].fieldRequest, orderByType)
         };
@@ -116,6 +117,7 @@ export class OutputTypeGenerator {
             // if we skip both, entity extensions will be passed as null, but they will only ever be used to look up
             // fields in them, and a FieldQueryNode returns null if the source is null.
             skipNullCheck: field.type.isEntityExtensionType,
+            isPure: true,
             resolve: (sourceNode) => createFieldNode(field, sourceNode, { skipNullFallbackForEntityExtensions: true })
         };
 
@@ -140,6 +142,7 @@ export class OutputTypeGenerator {
             type: new QueryNodeNonNullType(metaType),
             skipNullCheck: true, // meta fields should never be null
             description: field.description,
+            isPure: true,
             resolve: (sourceNode) => createFieldNode(field, sourceNode)
         };
         return this.filterAugmentation.augment(plainField, field.type);

--- a/src/schema-generation/query-node-object-type/definition.ts
+++ b/src/schema-generation/query-node-object-type/definition.ts
@@ -24,6 +24,13 @@ export interface QueryNodeField {
      * NULL is passed to the field resolvers within.
      */
     skipNullCheck?: boolean
+
+    /**
+     * If set to `true`, multiple identical invocations of this field can be optimized to require only one computation.
+     *
+     * Pure fields are assumed to be pure all the way down - the purity of nested fields is not checked.
+     */
+    isPure?: boolean
 }
 
 export interface QueryNodeObjectType {

--- a/src/schema-generation/query-type-generator.ts
+++ b/src/schema-generation/query-type-generator.ts
@@ -46,6 +46,7 @@ export class QueryTypeGenerator {
             name: namespace.name || '',
             type: new QueryNodeNonNullType(this.generate(namespace)),
             description: `The Query type for the namespace "${namespace.dotSeparatedPath}"`,
+            isPure: true,
             resolve: () => new ObjectQueryNode([])
         };
     }
@@ -74,6 +75,7 @@ export class QueryTypeGenerator {
             type: this.outputTypeGenerator.generate(rootEntityType),
             args: getArgumentsForUniqueFields(rootEntityType),
             description,
+            isPure: true,
             resolve: (_, args, info) => this.getSingleRootEntityNode(rootEntityType, args, info)
         };
     }
@@ -87,6 +89,7 @@ export class QueryTypeGenerator {
             name: getAllEntitiesFieldName(rootEntityType.name),
             type: new QueryNodeListType(new QueryNodeNonNullType(this.outputTypeGenerator.generate(rootEntityType))),
             description: rootEntityType.description,
+            isPure: true,
             resolve: () => this.getAllRootEntitiesNode(rootEntityType)
         });
         return this.listAugmentation.augment(fieldConfig, rootEntityType);
@@ -106,6 +109,7 @@ export class QueryTypeGenerator {
             // an unnecessary variable with the collection contents (which is slow) and we would to an equality check of
             // a collection against NULL which is deadly (v8 evaluation)
             skipNullCheck: true,
+            isPure: true,
             resolve: () => this.getAllRootEntitiesNode(rootEntityType)
         });
         return this.metaFirstAugmentation.augment(this.filterAugmentation.augment(fieldConfig, rootEntityType));

--- a/src/utils/group-by-equivalence.ts
+++ b/src/utils/group-by-equivalence.ts
@@ -1,0 +1,23 @@
+/**
+ * Partitions an array into equivalence classes, where the equality relation is defined by a callback
+ *
+ * The time complexity is O(n*m), where n is the number of items and n is the number of equivalence classes
+ */
+export function groupByEquivalence<T>(items: ReadonlyArray<T>, equals: (a: T, b: T) => boolean): ReadonlyArray<ReadonlyArray<T>> {
+    // credits for the algorithm to https://stackoverflow.com/questions/48177538/is-there-a-subquadratic-algorithm-to-partition-items-into-equivalence-classes
+    const groups: T[][] = [];
+    for (const item of items) {
+        let foundGroup = false;
+        for (const group of groups) {
+            if (equals(item, group[0])) {
+                group.push(item);
+                foundGroup = true;
+                break;
+            }
+        }
+        if (!foundGroup) {
+            groups.push([item]);
+        }
+    }
+    return groups;
+}


### PR DESCRIPTION
This is useful if e.g. a count is requested with potentially different
filters. If those filters are actually identical, the count will only
be calculated once.