### PR TITLE
Fix self-import of type SchemaExecutionArgs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: [push]
+on: [push, pull_request]
 jobs:
     test:
         runs-on: ubuntu-latest

--- a/src/execution/schema-executor.ts
+++ b/src/execution/schema-executor.ts
@@ -13,7 +13,6 @@ import { arrayToObject } from '../utils/utils';
 import { ExecutionOptions } from './execution-options';
 import { ExecutionResult } from './execution-result';
 import { OperationResolver } from './operation-resolver';
-import { SchemaExecutionArgs } from './schema-executor';
 
 type ValidationResult = { readonly canExecute: false, errorMessage: string } | SuccessfulValidationResult
 


### PR DESCRIPTION
`schema-executor` imported `SchemaExecutionArgs` from `schema-executor` which is 
not necessary and now an error in TypeScript 3.7