### PR TITLE
Fix schema validation error on empty orderBy types

### DIFF
--- a/spec/regression/no-root-entity-order-by/default-context.json
+++ b/spec/regression/no-root-entity-order-by/default-context.json
@@ -1,0 +1,3 @@
+{
+    "authRoles": ["users"]
+}

--- a/spec/regression/no-root-entity-order-by/model/model.graphqls
+++ b/spec/regression/no-root-entity-order-by/model/model.graphqls
@@ -1,0 +1,13 @@
+type Delivery @rootEntity {
+    deliveryNumber: String @key
+    orderDatas: [ShipmentData]
+    orders: [Shipment] @relation
+}
+
+type ShipmentData @valueObject {
+    shipment: Shipment @reference
+}
+
+type Shipment @rootEntity {
+    shipmentNumber: String @key
+}

--- a/spec/regression/no-root-entity-order-by/model/permission-profiles.json
+++ b/spec/regression/no-root-entity-order-by/model/permission-profiles.json
@@ -1,0 +1,12 @@
+{
+    "permissionProfiles": {
+        "default": {
+            "permissions": [
+                {
+                    "roles": ["users"],
+                    "access": "readWrite"
+                }
+            ]
+        }
+    }
+}

--- a/spec/regression/no-root-entity-order-by/options.json
+++ b/spec/regression/no-root-entity-order-by/options.json
@@ -1,0 +1,5 @@
+{
+    "schemaOptions": {
+        "maxOrderByRootEntityDepth": 0
+    }
+}

--- a/spec/regression/no-root-entity-order-by/test-data.json
+++ b/spec/regression/no-root-entity-order-by/test-data.json
@@ -1,0 +1,4 @@
+{
+    "roles": ["users"],
+    "rootEntities": {}
+}

--- a/spec/regression/no-root-entity-order-by/tests/introspection.graphql
+++ b/spec/regression/no-root-entity-order-by/tests/introspection.graphql
@@ -1,0 +1,30 @@
+{
+    # should not exist
+    shipmentDataOrderByType: __type(name: "ShipmentDataOrderBy") {
+        name
+    }
+
+    # should exist
+    shipmentOrderByType: __type(name: "ShipmentOrderBy") {
+        name
+    }
+
+    # should not include orderBy for shipmentDatas, but for shipments
+    deliveryType: __type(name: "Delivery") {
+        fields {
+            name
+            args {
+                name
+                type {
+                    name
+                    ofType {
+                        name
+                        ofType {
+                            name
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/spec/regression/no-root-entity-order-by/tests/introspection.result.json
+++ b/spec/regression/no-root-entity-order-by/tests/introspection.result.json
@@ -1,0 +1,127 @@
+{
+    "data": {
+        "shipmentDataOrderByType": null,
+        "shipmentOrderByType": {
+            "name": "ShipmentOrderBy"
+        },
+        "deliveryType": {
+            "fields": [
+                {
+                    "name": "id",
+                    "args": []
+                },
+                {
+                    "name": "createdAt",
+                    "args": []
+                },
+                {
+                    "name": "updatedAt",
+                    "args": []
+                },
+                {
+                    "name": "deliveryNumber",
+                    "args": []
+                },
+                {
+                    "name": "orderDatas",
+                    "args": [
+                        {
+                            "name": "filter",
+                            "type": {
+                                "name": "ShipmentDataFilter",
+                                "ofType": null
+                            }
+                        },
+                        {
+                            "name": "skip",
+                            "type": {
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        },
+                        {
+                            "name": "first",
+                            "type": {
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "_orderDatasMeta",
+                    "args": [
+                        {
+                            "name": "filter",
+                            "type": {
+                                "name": "ShipmentDataFilter",
+                                "ofType": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "orders",
+                    "args": [
+                        {
+                            "name": "filter",
+                            "type": {
+                                "name": "ShipmentFilter",
+                                "ofType": null
+                            }
+                        },
+                        {
+                            "name": "orderBy",
+                            "type": {
+                                "name": null,
+                                "ofType": {
+                                    "name": null,
+                                    "ofType": {
+                                        "name": "ShipmentOrderBy"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "name": "after",
+                            "type": {
+                                "name": "String",
+                                "ofType": null
+                            }
+                        },
+                        {
+                            "name": "skip",
+                            "type": {
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        },
+                        {
+                            "name": "first",
+                            "type": {
+                                "name": "Int",
+                                "ofType": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "_ordersMeta",
+                    "args": [
+                        {
+                            "name": "filter",
+                            "type": {
+                                "name": "ShipmentFilter",
+                                "ofType": null
+                            }
+                        }
+                    ]
+                },
+                {
+                    "name": "_cursor",
+                    "args": []
+                }
+            ]
+        }
+    }
+}

--- a/spec/regression/regression-suite.ts
+++ b/spec/regression/regression-suite.ts
@@ -56,6 +56,11 @@ export class RegressionSuite {
     }
 
     private async setUp() {
+        const optionsPath = path.resolve(this.path, 'options.json');
+        const options = fs.existsSync(optionsPath)
+            ? JSON.parse(stripJsonComments(fs.readFileSync(optionsPath, 'utf-8')))
+            : {};
+
         this.inMemoryDB = new InMemoryDB();
         const generalOptions: ProjectOptions = {
             processError: e => {
@@ -69,6 +74,7 @@ export class RegressionSuite {
             modelValidationOptions: {
                 forbiddenRootEntityNames: []
             },
+            ...options,
             getOperationIdentifier: ({ info }) => info.operation
         };
         const warnLevelOptions = { ...generalOptions, loggerProvider: new Log4jsLoggerProvider('warn') };

--- a/src/query-tree/lists.ts
+++ b/src/query-tree/lists.ts
@@ -29,13 +29,13 @@ export class ListQueryNode extends QueryNode {
  */
 export class TransformListQueryNode extends QueryNode {
     constructor(params: {
-        listNode: QueryNode,
-        innerNode?: QueryNode,
-        filterNode?: QueryNode,
-        orderBy?: OrderSpecification,
-        skip?: number,
-        maxCount?: number
-        itemVariable?: VariableQueryNode
+        listNode: QueryNode;
+        innerNode?: QueryNode;
+        filterNode?: QueryNode;
+        orderBy?: OrderSpecification;
+        skip?: number;
+        maxCount?: number;
+        itemVariable?: VariableQueryNode;
     }) {
         super();
         this.itemVariable = params.itemVariable || new VariableQueryNode();
@@ -56,15 +56,18 @@ export class TransformListQueryNode extends QueryNode {
     public readonly itemVariable: VariableQueryNode;
 
     describe() {
-        return `${this.listNode.describe()} as list with ${this.itemVariable.describe()} => \n` + indent('' + // '' to move the arg label here in WebStorm
-            (this.filterNode.equals(ConstBoolQueryNode.TRUE) ? '' : `where ${this.filterNode.describe()}\n`) +
-            (this.orderBy.isUnordered() ? '' : `order by ${this.orderBy.describe()}\n`) +
-            (this.skip != 0 ? `skip ${this.skip}\n` : '') +
-            (this.maxCount != undefined ? `limit ${this.maxCount}\n` : '') +
-            `as ${this.innerNode.describe()}`
+        return (
+            `${this.listNode.describe()} as list with ${this.itemVariable.describe()} => \n` +
+            indent(
+                '' + // '' to move the arg label here in WebStorm
+                    (this.filterNode.equals(ConstBoolQueryNode.TRUE) ? '' : `where ${this.filterNode.describe()}\n`) +
+                    (this.orderBy.isUnordered() ? '' : `order by ${this.orderBy.describe()}\n`) +
+                    (this.skip != 0 ? `skip ${this.skip}\n` : '') +
+                    (this.maxCount != undefined ? `limit ${this.maxCount}\n` : '') +
+                    `as ${this.innerNode.describe()}`
+            )
         );
     }
-
 }
 
 export class OrderClause extends QueryNode {
@@ -88,6 +91,8 @@ export class OrderSpecification extends QueryNode {
     constructor(public readonly clauses: ReadonlyArray<OrderClause>) {
         super();
     }
+
+    static readonly UNORDERED = new OrderSpecification([]);
 
     isUnordered() {
         return this.clauses.length == 0;
@@ -120,9 +125,7 @@ export class ConcatListsQueryNode extends QueryNode {
         if (!this.listNodes.length) {
             return `[]`;
         }
-        return `[\n` +
-            this.listNodes.map(node => indent('...' + node.describe())).join(',\n') +
-            `]`;
+        return `[\n` + this.listNodes.map(node => indent('...' + node.describe())).join(',\n') + `]`;
     }
 }
 
@@ -153,13 +156,17 @@ export class FirstOfListQueryNode extends QueryNode {
 }
 
 interface AggregationQueryNodeParams {
-    sort?: boolean
+    sort?: boolean;
 }
 
 export class AggregationQueryNode extends QueryNode {
     readonly sort: boolean;
 
-    constructor(readonly listNode: QueryNode, readonly operator: AggregationOperator, options: AggregationQueryNodeParams = {}) {
+    constructor(
+        readonly listNode: QueryNode,
+        readonly operator: AggregationOperator,
+        options: AggregationQueryNodeParams = {}
+    ) {
         super();
         this.sort = options.sort || false;
     }

--- a/src/schema-generation/order-by-and-pagination-augmentation.ts
+++ b/src/schema-generation/order-by-and-pagination-augmentation.ts
@@ -1,21 +1,39 @@
 import { GraphQLInt, GraphQLList, GraphQLNonNull, GraphQLString } from 'graphql';
 import { Type } from '../model';
-import { BinaryOperationQueryNode, BinaryOperator, ConcatListsQueryNode, ConstBoolQueryNode, INVALID_CURSOR_ERROR, LiteralQueryNode, OrderDirection, OrderSpecification, QueryNode, RuntimeErrorQueryNode, TransformListQueryNode, VariableQueryNode } from '../query-tree';
-import { AFTER_ARG, CURSOR_FIELD, FIRST_ARG, ID_FIELD, ORDER_BY_ARG, ORDER_BY_ASC_SUFFIX, SKIP_ARG } from '../schema/constants';
+import {
+    BinaryOperationQueryNode,
+    BinaryOperator,
+    ConcatListsQueryNode,
+    ConstBoolQueryNode,
+    INVALID_CURSOR_ERROR,
+    LiteralQueryNode,
+    OrderDirection,
+    OrderSpecification,
+    QueryNode,
+    RuntimeErrorQueryNode,
+    TransformListQueryNode,
+    VariableQueryNode
+} from '../query-tree';
+import {
+    AFTER_ARG,
+    CURSOR_FIELD,
+    FIRST_ARG,
+    ID_FIELD,
+    ORDER_BY_ARG,
+    ORDER_BY_ASC_SUFFIX,
+    SKIP_ARG
+} from '../schema/constants';
 import { decapitalize } from '../utils/utils';
-import { and } from './utils/input-types';
 import { OrderByEnumGenerator, OrderByEnumType, OrderByEnumValue } from './order-by-enum-generator';
 import { QueryNodeField } from './query-node-object-type';
+import { and } from './utils/input-types';
 import { getOrderByValues } from './utils/pagination';
 
 /**
  * Augments list fields with orderBy argument
  */
 export class OrderByAndPaginationAugmentation {
-    constructor(
-        private readonly orderByEnumGenerator: OrderByEnumGenerator
-    ) {
-    }
+    constructor(private readonly orderByEnumGenerator: OrderByEnumGenerator) {}
 
     augment(schemaField: QueryNodeField, type: Type): QueryNodeField {
         if (!type.isObjectType) {
@@ -28,16 +46,27 @@ export class OrderByAndPaginationAugmentation {
             ...schemaField,
             args: {
                 ...schemaField.args,
-                [ORDER_BY_ARG]: {
-                    type: new GraphQLList(new GraphQLNonNull(orderByType.getEnumType())),
-                    description: `Specifies the how this ${type.isRootEntityType ? 'collection' : 'list'} should be sorted. If omitted, ` + (
-                        type.isRootEntityType ? `the result order is not specified. ` : `the order of the list in the object is preserved. `
-                    ) + (
-                        type.isRootEntityType || type.isChildEntityType ?
-                            `If cursor-based pagination is used (i.e., the \`${AFTER_ARG}\` is specified or the \`${CURSOR_FIELD}\` is requested), \`${ID_FIELD}${ORDER_BY_ASC_SUFFIX}\` will be implicitly added as last sort criterion so that the sort order is deterministic.` :
-                            `When using cursor-based pagination, ensure that you specify a field with unique values so that the order is deterministic.`
-                    )
-                },
+                ...(orderByType
+                    ? {
+                          [ORDER_BY_ARG]: {
+                              type: new GraphQLList(new GraphQLNonNull(orderByType.getEnumType())),
+                              description:
+                                  `Specifies the how this ${
+                                      type.isRootEntityType ? 'collection' : 'list'
+                                  } should be sorted. If omitted, ` +
+                                  (type.isRootEntityType
+                                      ? `the result order is not specified. `
+                                      : `the order of the list in the object is preserved. `) +
+                                  (type.isRootEntityType || type.isChildEntityType
+                                      ? `If cursor-based pagination is used (i.e., the \`${AFTER_ARG}\` is specified or the \`${CURSOR_FIELD}\` is requested), \`${ID_FIELD}${ORDER_BY_ASC_SUFFIX}\` will be implicitly added as last sort criterion so that the sort order is deterministic.`
+                                      : `When using cursor-based pagination, ensure that you specify a field with unique values so that the order is deterministic.`)
+                          },
+                          [AFTER_ARG]: {
+                              type: GraphQLString,
+                              description: `If this is set to the value of the \`${CURSOR_FIELD}\` field of an item, only items after that one will be included in the result. The value of the \`${AFTER_ARG}\` of this query must match the one where the \`${CURSOR_FIELD}\` value has been retrieved from.`
+                          }
+                      }
+                    : {}),
                 [SKIP_ARG]: {
                     type: GraphQLInt,
                     description: `The number of items in the list or collection to skip. Is applied after the \`${AFTER_ARG}\` argument if both are specified.`
@@ -45,10 +74,6 @@ export class OrderByAndPaginationAugmentation {
                 [FIRST_ARG]: {
                     type: GraphQLInt,
                     description: `The number of items to include in the result. If omitted, all remaining items will be included (which can cause performance problems on large collections).`
-                },
-                [AFTER_ARG]: {
-                    type: GraphQLString,
-                    description: `If this is set to the value of the \`${CURSOR_FIELD}\` field of an item, only items after that one will be included in the result. The value of the \`${AFTER_ARG}\` of this query must match the one where the \`${CURSOR_FIELD}\` value has been retrieved from.`
                 }
             },
             resolve: (sourceNode, args, info) => {
@@ -59,11 +84,13 @@ export class OrderByAndPaginationAugmentation {
                 // (e.g. projection indirection)
                 let filterNode: QueryNode | undefined;
                 const originalListNode = listNode;
-                if (listNode instanceof TransformListQueryNode
-                    && listNode.skip === 0
-                    && listNode.orderBy.isUnordered()
-                    && listNode.maxCount == undefined
-                    && listNode.innerNode === listNode.itemVariable) {
+                if (
+                    listNode instanceof TransformListQueryNode &&
+                    listNode.skip === 0 &&
+                    listNode.orderBy.isUnordered() &&
+                    listNode.maxCount == undefined &&
+                    listNode.innerNode === listNode.itemVariable
+                ) {
                     filterNode = listNode.filterNode.equals(ConstBoolQueryNode.TRUE) ? undefined : listNode.filterNode;
                     itemVariable = listNode.itemVariable;
                     listNode = listNode.listNode;
@@ -71,24 +98,44 @@ export class OrderByAndPaginationAugmentation {
 
                 const maxCount: number | undefined = args[FIRST_ARG];
                 const skip = args[SKIP_ARG];
-                const paginationFilter = this.createPaginationFilterNode(args, itemVariable, orderByType);
+                const paginationFilter =
+                    orderByType && this.createPaginationFilterNode(args, itemVariable, orderByType);
                 const afterArg = args[AFTER_ARG];
-                const isCursorRequested = info.selectionStack[info.selectionStack.length - 1].fieldRequest.selectionSet.some(sel => sel.fieldRequest.field.name === CURSOR_FIELD);
+                const isCursorRequested = info.selectionStack[
+                    info.selectionStack.length - 1
+                ].fieldRequest.selectionSet.some(sel => sel.fieldRequest.field.name === CURSOR_FIELD);
                 // we only require the absolute ordering for cursor-based pagination, which is detected via a cursor field or the "after" argument.
                 const isAbsoluteOrderRequired = isCursorRequested || !!afterArg;
-                const orderBy = this.getOrderSpecification(args, orderByType, itemVariable, { isAbsoluteOrderRequired });
+                const orderBy = !orderByType
+                    ? OrderSpecification.UNORDERED
+                    : this.getOrderSpecification(args, orderByType, itemVariable, { isAbsoluteOrderRequired });
 
                 if (orderBy.isUnordered() && maxCount == undefined && paginationFilter === ConstBoolQueryNode.TRUE) {
                     return originalListNode;
                 }
 
-                if (!skip && maxCount != undefined && orderBy.clauses.length > 1 && afterArg && type.isRootEntityType) {
+                if (
+                    !skip &&
+                    maxCount != undefined &&
+                    orderBy.clauses.length > 1 &&
+                    afterArg &&
+                    type.isRootEntityType &&
+                    orderByType
+                ) {
                     // optimization that makes use of an index that spans multiple order fields
                     // see https://github.com/arangodb/arangodb/issues/2357
                     // TODO only really do this here if there is an index covering this
                     // (however, it's not that easy - it needs to include the filter stuff that is already baked into
                     // listNode)
-                    return this.getPaginatedNodeUsingMultiIndexOptimization({ orderBy, itemVariable, orderByType, listNode, args, maxCount, filterNode });
+                    return this.getPaginatedNodeUsingMultiIndexOptimization({
+                        orderBy,
+                        itemVariable,
+                        orderByType,
+                        listNode,
+                        args,
+                        maxCount,
+                        filterNode
+                    });
                 }
 
                 return new TransformListQueryNode({
@@ -97,22 +144,46 @@ export class OrderByAndPaginationAugmentation {
                     orderBy,
                     skip,
                     maxCount,
-                    filterNode: filterNode && paginationFilter ? and(filterNode, paginationFilter) : (filterNode || paginationFilter)
+                    filterNode:
+                        filterNode && paginationFilter
+                            ? and(filterNode, paginationFilter)
+                            : filterNode || paginationFilter
                 });
             }
         };
-    };
+    }
 
-    private getPaginatedNodeUsingMultiIndexOptimization({ args, orderByType, itemVariable, listNode, orderBy, maxCount, filterNode }: { args: { [name: string]: any }, orderByType: OrderByEnumType, itemVariable: VariableQueryNode, listNode: QueryNode, orderBy: OrderSpecification, maxCount: number | undefined, filterNode: QueryNode | undefined }) {
+    private getPaginatedNodeUsingMultiIndexOptimization({
+        args,
+        orderByType,
+        itemVariable,
+        listNode,
+        orderBy,
+        maxCount,
+        filterNode
+    }: {
+        args: { [name: string]: any };
+        orderByType: OrderByEnumType;
+        itemVariable: VariableQueryNode;
+        listNode: QueryNode;
+        orderBy: OrderSpecification;
+        maxCount: number | undefined;
+        filterNode: QueryNode | undefined;
+    }) {
         const afterArg = args[AFTER_ARG];
         let cursorObj: any;
         try {
             cursorObj = JSON.parse(afterArg);
             if (typeof cursorObj != 'object' || cursorObj === null) {
-                return new RuntimeErrorQueryNode('The JSON value provided as "after" argument is not an object', { code: INVALID_CURSOR_ERROR });
+                return new RuntimeErrorQueryNode('The JSON value provided as "after" argument is not an object', {
+                    code: INVALID_CURSOR_ERROR
+                });
             }
         } catch (e) {
-            return new RuntimeErrorQueryNode(`Invalid cursor ${JSON.stringify(afterArg)} supplied to "after": ${e.message}`, { code: INVALID_CURSOR_ERROR });
+            return new RuntimeErrorQueryNode(
+                `Invalid cursor ${JSON.stringify(afterArg)} supplied to "after": ${e.message}`,
+                { code: INVALID_CURSOR_ERROR }
+            );
         }
 
         let currentEqualityChain: QueryNode | undefined = filterNode;
@@ -121,16 +192,26 @@ export class OrderByAndPaginationAugmentation {
         for (const clause of orderByValues) {
             const cursorProperty = clause.underscoreSeparatedPath;
             if (!(cursorProperty in cursorObj)) {
-                return new RuntimeErrorQueryNode(`Invalid cursor supplied to "after": Property "${cursorProperty}" missing. Make sure this cursor has been obtained with the same orderBy clause.`, { code: INVALID_CURSOR_ERROR });
+                return new RuntimeErrorQueryNode(
+                    `Invalid cursor supplied to "after": Property "${cursorProperty}" missing. Make sure this cursor has been obtained with the same orderBy clause.`,
+                    { code: INVALID_CURSOR_ERROR }
+                );
             }
             const cursorValue = cursorObj[cursorProperty];
             const valueNode = clause.getValueNode(itemVariable);
 
-            const operator = clause.direction == OrderDirection.ASCENDING ? BinaryOperator.GREATER_THAN : BinaryOperator.LESS_THAN;
+            const operator =
+                clause.direction == OrderDirection.ASCENDING ? BinaryOperator.GREATER_THAN : BinaryOperator.LESS_THAN;
             const unequalityNode = new BinaryOperationQueryNode(valueNode, operator, new LiteralQueryNode(cursorValue));
             const filterNode = currentEqualityChain ? and(currentEqualityChain, unequalityNode) : unequalityNode;
-            const nextEqualityNode = new BinaryOperationQueryNode(valueNode, BinaryOperator.EQUAL, new LiteralQueryNode(cursorValue));
-            currentEqualityChain = currentEqualityChain ? and(currentEqualityChain, nextEqualityNode) : nextEqualityNode;
+            const nextEqualityNode = new BinaryOperationQueryNode(
+                valueNode,
+                BinaryOperator.EQUAL,
+                new LiteralQueryNode(cursorValue)
+            );
+            currentEqualityChain = currentEqualityChain
+                ? and(currentEqualityChain, nextEqualityNode)
+                : nextEqualityNode;
 
             const partListNode = new TransformListQueryNode({
                 listNode,
@@ -150,13 +231,22 @@ export class OrderByAndPaginationAugmentation {
         });
     }
 
-    private getOrderSpecification(args: any, orderByType: OrderByEnumType, itemNode: QueryNode, options: { readonly isAbsoluteOrderRequired: boolean }) {
+    private getOrderSpecification(
+        args: any,
+        orderByType: OrderByEnumType,
+        itemNode: QueryNode,
+        options: { readonly isAbsoluteOrderRequired: boolean }
+    ) {
         const mappedValues = getOrderByValues(args, orderByType, options);
         const clauses = mappedValues.map(value => value.getClause(itemNode));
         return new OrderSpecification(clauses);
     }
 
-    private createPaginationFilterNode(args: any, itemNode: QueryNode, orderByType: OrderByEnumType): QueryNode | undefined {
+    private createPaginationFilterNode(
+        args: any,
+        itemNode: QueryNode,
+        orderByType: OrderByEnumType
+    ): QueryNode | undefined {
         const afterArg = args[AFTER_ARG];
         if (!afterArg) {
             return undefined;
@@ -166,10 +256,15 @@ export class OrderByAndPaginationAugmentation {
         try {
             cursorObj = JSON.parse(afterArg);
             if (typeof cursorObj != 'object' || cursorObj === null) {
-                return new RuntimeErrorQueryNode('The JSON value provided as "after" argument is not an object', { code: INVALID_CURSOR_ERROR });
+                return new RuntimeErrorQueryNode('The JSON value provided as "after" argument is not an object', {
+                    code: INVALID_CURSOR_ERROR
+                });
             }
         } catch (e) {
-            return new RuntimeErrorQueryNode(`Invalid cursor ${JSON.stringify(afterArg)} supplied to "after": ${e.message}`, { code: INVALID_CURSOR_ERROR });
+            return new RuntimeErrorQueryNode(
+                `Invalid cursor ${JSON.stringify(afterArg)} supplied to "after": ${e.message}`,
+                { code: INVALID_CURSOR_ERROR }
+            );
         }
 
         // Make sure we only select items after the cursor
@@ -189,12 +284,16 @@ export class OrderByAndPaginationAugmentation {
             const clause = clauses[0];
             const cursorProperty = clause.underscoreSeparatedPath;
             if (!(cursorProperty in cursorObj)) {
-                return new RuntimeErrorQueryNode(`Invalid cursor supplied to "after": Property "${cursorProperty}" missing. Make sure this cursor has been obtained with the same orderBy clause.`, { code: INVALID_CURSOR_ERROR });
+                return new RuntimeErrorQueryNode(
+                    `Invalid cursor supplied to "after": Property "${cursorProperty}" missing. Make sure this cursor has been obtained with the same orderBy clause.`,
+                    { code: INVALID_CURSOR_ERROR }
+                );
             }
             const cursorValue = cursorObj[cursorProperty];
             const valueNode = clause.getValueNode(itemNode);
 
-            const operator = clause.direction == OrderDirection.ASCENDING ? BinaryOperator.GREATER_THAN : BinaryOperator.LESS_THAN;
+            const operator =
+                clause.direction == OrderDirection.ASCENDING ? BinaryOperator.GREATER_THAN : BinaryOperator.LESS_THAN;
             return new BinaryOperationQueryNode(
                 new BinaryOperationQueryNode(valueNode, operator, new LiteralQueryNode(cursorValue)),
                 BinaryOperator.OR,

--- a/src/schema-generation/order-by-enum-generator.ts
+++ b/src/schema-generation/order-by-enum-generator.ts
@@ -110,9 +110,16 @@ interface RecursionOptions {
 export class OrderByEnumGenerator {
     constructor(private readonly config: OrderByEnumGeneratorConfig = {}) {}
 
+    /**
+     * Generate the OrderBy type for an object type, or undefined if has not any fields to order by
+     */
     @memorize()
-    generate(objectType: ObjectType) {
-        return new OrderByEnumType(objectType, this.getValues(objectType));
+    generate(objectType: ObjectType): OrderByEnumType | undefined {
+        const values = this.getValues(objectType);
+        if (!values.length) {
+            return undefined;
+        }
+        return new OrderByEnumType(objectType, values);
     }
 
     private getValues(type: ObjectType, options?: RecursionOptions): ReadonlyArray<OrderByEnumValue> {


### PR DESCRIPTION
Some objects may have no orderBy type, e.g. value objects that only
include rootEntityType-typed fields if maxRootEntityOrderByDepth is 0.