### PR TITLE
Support @collect with accessGroup

### DIFF
--- a/spec/regression/collect/model/model.graphqls
+++ b/spec/regression/collect/model/model.graphqls
@@ -1,6 +1,6 @@
 type Shipment @rootEntity {
     shipmentNumber: String @key
-
+    accessGroup: String
 
     deliveries: [Delivery] @relation
 
@@ -25,6 +25,7 @@ type Shipment @rootEntity {
 
 type Delivery @rootEntity {
     deliveryNumber: String @key
+    accessGroup: String
     dispatchedAt: OffsetDateTime
     priority: Int
     deliveryContents: [DeliveryContent]
@@ -69,6 +70,7 @@ type Delivery @rootEntity {
 
 type HandlingUnit @rootEntity {
     handlingUnitNumber: String @key
+    accessGroup: String
     warehouseSlot: WarehouseSlot
 
     deliveries: [Delivery] @relation(inverseOf: "handlingUnits")
@@ -80,6 +82,7 @@ type HandlingUnit @rootEntity {
 
 type Order @rootEntity {
     orderNumber: String @key
+    accessGroup: String
     payedAt: DateTime
 
     delivery: Delivery @relation(inverseOf: "order")

--- a/spec/regression/collect/model/permission-profiles.json
+++ b/spec/regression/collect/model/permission-profiles.json
@@ -1,14 +1,27 @@
 {
-  "permissionProfiles": {
-    "default": {
-      "permissions": [
-        {
-          "roles": [
-            "users"
-          ],
-          "access": "readWrite"
+    "permissionProfiles": {
+        "default": {
+            "permissions": [
+                {
+                    "roles": ["users"],
+                    "access": "readWrite"
+                },
+                {
+                    "roles": ["d1s1"],
+                    "access": "readWrite",
+                    "restrictToAccessGroups": ["D1", "S1"]
+                },
+                {
+                    "roles": ["s1d2d3h1h3h4o2o3"],
+                    "access": "readWrite",
+                    "restrictToAccessGroups": ["S1", "D2", "D3", "H1", "H3", "H4", "O2", "O3"]
+                },
+                {
+                    "roles": ["h1h2"],
+                    "access": "readWrite",
+                    "restrictToAccessGroups": ["D1", "S1", "H1", "H2"]
+                }
+            ]
         }
-      ]
     }
-  }
 }

--- a/spec/regression/collect/test-data.json
+++ b/spec/regression/collect/test-data.json
@@ -5,6 +5,7 @@
             {
                 "@id": "1",
                 "deliveryNumber": "D1",
+                "accessGroup": "D1",
                 "dispatchedAt": "2020-01-30T10:00:00+01:00",
                 "priority": 1,
                 "deliveryContents": [
@@ -41,6 +42,7 @@
             {
                 "@id": "2",
                 "deliveryNumber": "D2",
+                "accessGroup": "D2",
                 "dispatchedAt": "2020-01-30T11:00:00+03:00",
                 "priority": 3,
                 "deliveryContents": [
@@ -75,6 +77,7 @@
             {
                 "@id": "3",
                 "deliveryNumber": "D3",
+                "accessGroup": "D3",
                 "priority": 2,
                 "deliveryContents": [
                     {
@@ -105,6 +108,7 @@
             {
                 "@id": "4",
                 "deliveryNumber": "D4",
+                "accessGroup": "D4",
                 "deliveryContents": [
                     {
                         "deliveryContentNumber": "DC4.1",
@@ -133,6 +137,7 @@
             {
                 "@id": "5",
                 "deliveryNumber": "D5",
+                "accessGroup": "D5",
                 "deliveryContents": [
                     {
                         "deliveryContentNumber": "DC5.1"
@@ -151,25 +156,30 @@
         "Shipment": [
             {
                 "@id": "1",
-                "shipmentNumber": "S1"
+                "shipmentNumber": "S1",
+                "accessGroup": "S1"
             },
             {
                 "@id": "2",
-                "shipmentNumber": "S2"
+                "shipmentNumber": "S2",
+                "accessGroup": "S2"
             },
             {
                 "@id": "3",
-                "shipmentNumber": "S3"
+                "shipmentNumber": "S3",
+                "accessGroup": "S3"
             },
             {
                 "@id": "4",
-                "shipmentNumber": "S4"
+                "shipmentNumber": "S4",
+                "accessGroup": "S4"
             }
         ],
         "HandlingUnit": [
             {
                 "@id": "1",
                 "handlingUnitNumber": "H1",
+                "accessGroup": "H1",
                 "warehouseSlot": {
                     "warehouse": "South",
                     "level": 0
@@ -178,6 +188,7 @@
             {
                 "@id": "2",
                 "handlingUnitNumber": "H2",
+                "accessGroup": "H2",
                 "warehouseSlot": {
                     "warehouse": "South",
                     "level": 1
@@ -186,6 +197,7 @@
             {
                 "@id": "3",
                 "handlingUnitNumber": "H3",
+                "accessGroup": "H3",
                 "warehouseSlot": {
                     "warehouse": "South",
                     "level": 0
@@ -194,6 +206,7 @@
             {
                 "@id": "4",
                 "handlingUnitNumber": "H4",
+                "accessGroup": "H4",
                 "warehouseSlot": {
                     "warehouse": "North",
                     "level": 0
@@ -204,19 +217,23 @@
             {
                 "@id": "1",
                 "orderNumber": "O1",
+                "accessGroup": "O1",
                 "payedAt": "2019-06-21T18:10:00Z"
             },
             {
                 "@id": "2",
-                "orderNumber": "O2"
+                "orderNumber": "O2",
+                "accessGroup": "O2"
             },
             {
                 "@id": "3",
-                "orderNumber": "O3"
+                "orderNumber": "O3",
+                "accessGroup": "O3"
             },
             {
                 "@id": "4",
-                "orderNumber": "O4"
+                "orderNumber": "O4",
+                "accessGroup": "O4"
             }
         ]
     }

--- a/spec/regression/collect/tests/collect-edge-count-access-group.context.json
+++ b/spec/regression/collect/tests/collect-edge-count-access-group.context.json
@@ -1,0 +1,8 @@
+{
+    "authRoles": ["d1s1"],
+    "operations": {
+        "createEdges": {
+            "authRoles": ["users"]
+        }
+    }
+}

--- a/spec/regression/collect/tests/collect-edge-count-access-group.graphql
+++ b/spec/regression/collect/tests/collect-edge-count-access-group.graphql
@@ -1,0 +1,14 @@
+mutation createEdges {
+    updateShipment(input: { id: "@{ids/Shipment/1}", addDeliveries: ["@{ids/Delivery/1}", "@{ids/Delivery/2}"] }) {
+        shipmentNumber
+    }
+}
+
+query count {
+    Shipment(shipmentNumber: "S1") {
+        _deliveriesMeta {
+            count
+        }
+        deliveryCount
+    }
+}

--- a/spec/regression/collect/tests/collect-edge-count-access-group.meta.json
+++ b/spec/regression/collect/tests/collect-edge-count-access-group.meta.json
@@ -1,0 +1,19 @@
+{
+    "databases": {
+        // @collect with accessGroup is not implemented in InMemoryAdapter
+        "in-memory": {
+            "ignore": true
+        },
+        "arangodb": {
+            "versions": {
+                // PRUNE support has been introduced in 3.4
+                "3.2": {
+                    "ignore": true
+                },
+                "3.3": {
+                    "ignore": true
+                }
+            }
+        }
+    }
+}

--- a/spec/regression/collect/tests/collect-edge-count-access-group.result.json
+++ b/spec/regression/collect/tests/collect-edge-count-access-group.result.json
@@ -1,0 +1,19 @@
+{
+    "createEdges": {
+        "data": {
+            "updateShipment": {
+                "shipmentNumber": "S1"
+            }
+        }
+    },
+    "count": {
+        "data": {
+            "Shipment": {
+                "_deliveriesMeta": {
+                    "count": 1
+                },
+                "deliveryCount": 1
+            }
+        }
+    }
+}

--- a/spec/regression/collect/tests/recursive-relation-traversal-access-group.context.json
+++ b/spec/regression/collect/tests/recursive-relation-traversal-access-group.context.json
@@ -1,0 +1,8 @@
+{
+    "authRoles": ["h1h2", "d1s1"],
+    "operations": {
+        "createEdges": {
+            "authRoles": ["users"]
+        }
+    }
+}

--- a/spec/regression/collect/tests/recursive-relation-traversal-access-group.graphql
+++ b/spec/regression/collect/tests/recursive-relation-traversal-access-group.graphql
@@ -1,0 +1,124 @@
+mutation createEdges {
+    updateShipment(input: { id: "@{ids/Shipment/1}", addDeliveries: ["@{ids/Delivery/1}", "@{ids/Delivery/2}"] }) {
+        shipmentNumber
+    }
+    d1: updateDelivery(
+        input: { id: "@{ids/Delivery/1}", addHandlingUnits: ["@{ids/HandlingUnit/1}", "@{ids/HandlingUnit/2}"] }
+    ) {
+        deliveryNumber
+    }
+    d2: updateDelivery(input: { id: "@{ids/Delivery/2}", addHandlingUnits: ["@{ids/HandlingUnit/3}"] }) {
+        deliveryNumber
+    }
+    h1: updateHandlingUnit(
+        input: {
+            id: "@{ids/HandlingUnit/1}"
+            createChildHandlingUnits: [
+                {
+                    handlingUnitNumber: "H1.1"
+                    accessGroup: "H1"
+                    createChildHandlingUnits: [
+                        { handlingUnitNumber: "H1.1.1", accessGroup: "H1" }
+                        { handlingUnitNumber: "H1.1.2", accessGroup: "restricted" }
+                    ]
+                }
+                {
+                    handlingUnitNumber: "H1.2"
+                    accessGroup: "restricted"
+                    createChildHandlingUnits: [
+                        { handlingUnitNumber: "H1.2.1", accessGroup: "H1" }
+                        { handlingUnitNumber: "H1.2.2", accessGroup: "H1" }
+                    ]
+                }
+            ]
+        }
+    ) {
+        handlingUnitNumber
+    }
+    h2: updateHandlingUnit(
+        input: {
+            id: "@{ids/HandlingUnit/2}"
+            createChildHandlingUnits: [
+                {
+                    handlingUnitNumber: "H2.1"
+                    accessGroup: "H2"
+                    createChildHandlingUnits: [{ handlingUnitNumber: "H2.1.1", accessGroup: "restricted" }]
+                }
+                { handlingUnitNumber: "H2.2", accessGroup: "H2" }
+            ]
+        }
+    ) {
+        handlingUnitNumber
+    }
+    h3: updateHandlingUnit(
+        input: {
+            id: "@{ids/HandlingUnit/3}"
+            createChildHandlingUnits: [
+                {
+                    handlingUnitNumber: "H3.1"
+                    accessGroup: "H3"
+                    createChildHandlingUnits: [{ handlingUnitNumber: "H3.1.1", accessGroup: "H1" }]
+                }
+                { handlingUnitNumber: "H3.2", accessGroup: "H3" }
+            ]
+        }
+    ) {
+        handlingUnitNumber
+    }
+}
+
+query direct0to1 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits0to1(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query direct0to2 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits0to2(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query direct1to1 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits1to1(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query direct1to2 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits1to2(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query direct2to2 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits2to2(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query direct3to3 {
+    Delivery(deliveryNumber: "D1") {
+        allHandlingUnits3to3(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query indirect {
+    Shipment(shipmentNumber: "S1") {
+        allHandlingUnits(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}

--- a/spec/regression/collect/tests/recursive-relation-traversal-access-group.meta.json
+++ b/spec/regression/collect/tests/recursive-relation-traversal-access-group.meta.json
@@ -1,0 +1,19 @@
+{
+    "databases": {
+        // recursive traversal as well as @collect with accessGroup is not implemented in InMemoryAdapter
+        "in-memory": {
+            "ignore": true
+        },
+        "arangodb": {
+            "versions": {
+                // PRUNE support has been introduced in 3.4
+                "3.2": {
+                    "ignore": true
+                },
+                "3.3": {
+                    "ignore": true
+                }
+            }
+        }
+    }
+}

--- a/spec/regression/collect/tests/recursive-relation-traversal-access-group.result.json
+++ b/spec/regression/collect/tests/recursive-relation-traversal-access-group.result.json
@@ -1,0 +1,154 @@
+{
+    "createEdges": {
+        "data": {
+            "updateShipment": {
+                "shipmentNumber": "S1"
+            },
+            "d1": {
+                "deliveryNumber": "D1"
+            },
+            "d2": {
+                "deliveryNumber": "D2"
+            },
+            "h1": {
+                "handlingUnitNumber": "H1"
+            },
+            "h2": {
+                "handlingUnitNumber": "H2"
+            },
+            "h3": {
+                "handlingUnitNumber": "H3"
+            }
+        }
+    },
+    "direct0to1": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits0to1": [
+                    {
+                        "handlingUnitNumber": "H1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.2"
+                    }
+                ]
+            }
+        }
+    },
+    "direct0to2": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits0to2": [
+                    {
+                        "handlingUnitNumber": "H1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.2"
+                    }
+                ]
+            }
+        }
+    },
+    "direct1to1": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits1to1": [
+                    {
+                        "handlingUnitNumber": "H1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.2"
+                    }
+                ]
+            }
+        }
+    },
+    "direct1to2": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits1to2": [
+                    {
+                        "handlingUnitNumber": "H1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.2"
+                    }
+                ]
+            }
+        }
+    },
+    "direct2to2": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits2to2": [
+                    {
+                        "handlingUnitNumber": "H1.1.1"
+                    }
+                ]
+            }
+        }
+    },
+    "direct3to3": {
+        "data": {
+            "Delivery": {
+                "allHandlingUnits3to3": []
+            }
+        }
+    },
+    "indirect": {
+        "data": {
+            "Shipment": {
+                "allHandlingUnits": [
+                    {
+                        "handlingUnitNumber": "H1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H1.1.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.1"
+                    },
+                    {
+                        "handlingUnitNumber": "H2.2"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/spec/regression/collect/tests/recursive-relation-traversal.meta.json
+++ b/spec/regression/collect/tests/recursive-relation-traversal.meta.json
@@ -1,8 +1,8 @@
 {
-  "databases": {
-    // recursive traversal is not implemented in InMemoryAdapter
-    "in-memory": {
-      "ignore": true
+    "databases": {
+        // recursive traversal is not implemented in InMemoryAdapter
+        "in-memory": {
+            "ignore": true
+        }
     }
-  }
 }

--- a/spec/regression/collect/tests/relation-traversal-access-group.context.json
+++ b/spec/regression/collect/tests/relation-traversal-access-group.context.json
@@ -1,0 +1,8 @@
+{
+    "authRoles": ["s1d2d3h1h3h4o2o3"],
+    "operations": {
+        "createEdges": {
+            "authRoles": ["users"]
+        }
+    }
+}

--- a/spec/regression/collect/tests/relation-traversal-access-group.graphql
+++ b/spec/regression/collect/tests/relation-traversal-access-group.graphql
@@ -1,0 +1,47 @@
+mutation createEdges {
+    updateShipment(input: { id: "@{ids/Shipment/1}", addDeliveries: ["@{ids/Delivery/1}", "@{ids/Delivery/2}"] }) {
+        shipmentNumber
+    }
+    d1: updateDelivery(
+        input: {
+            id: "@{ids/Delivery/1}"
+            addHandlingUnits: ["@{ids/HandlingUnit/1}", "@{ids/HandlingUnit/2}"]
+            order: "@{ids/Order/1}"
+        }
+    ) {
+        deliveryNumber
+    }
+    d2: updateDelivery(
+        input: {
+            id: "@{ids/Delivery/2}"
+            addHandlingUnits: ["@{ids/HandlingUnit/3}", "@{ids/HandlingUnit/2}"]
+            order: "@{ids/Order/2}"
+        }
+    ) {
+        deliveryNumber
+    }
+}
+
+query toNtoN {
+    Shipment(shipmentNumber: "S1") {
+        allOuterHandlingUnits(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}
+
+query toNto1 {
+    Shipment(shipmentNumber: "S1") {
+        allOrders(orderBy: orderNumber_ASC) {
+            orderNumber
+        }
+    }
+}
+
+query to1toN {
+    Order(orderNumber: "O2") {
+        allOuterHandlingUnits(orderBy: handlingUnitNumber_ASC) {
+            handlingUnitNumber
+        }
+    }
+}

--- a/spec/regression/collect/tests/relation-traversal-access-group.meta.json
+++ b/spec/regression/collect/tests/relation-traversal-access-group.meta.json
@@ -1,0 +1,19 @@
+{
+    "databases": {
+        // @collect with accessGroup is not implemented in InMemoryAdapter
+        "in-memory": {
+            "ignore": true
+        },
+        "arangodb": {
+            "versions": {
+                // PRUNE support has been introduced in 3.4
+                "3.2": {
+                    "ignore": true
+                },
+                "3.3": {
+                    "ignore": true
+                }
+            }
+        }
+    }
+}

--- a/spec/regression/collect/tests/relation-traversal-access-group.result.json
+++ b/spec/regression/collect/tests/relation-traversal-access-group.result.json
@@ -1,0 +1,48 @@
+{
+    "createEdges": {
+        "data": {
+            "updateShipment": {
+                "shipmentNumber": "S1"
+            },
+            "d1": {
+                "deliveryNumber": "D1"
+            },
+            "d2": {
+                "deliveryNumber": "D2"
+            }
+        }
+    },
+    "toNtoN": {
+        "data": {
+            "Shipment": {
+                "allOuterHandlingUnits": [
+                    {
+                        "handlingUnitNumber": "H3"
+                    }
+                ]
+            }
+        }
+    },
+    "toNto1": {
+        "data": {
+            "Shipment": {
+                "allOrders": [
+                    {
+                        "orderNumber": "O2"
+                    }
+                ]
+            }
+        }
+    },
+    "to1toN": {
+        "data": {
+            "Order": {
+                "allOuterHandlingUnits": [
+                    {
+                        "handlingUnitNumber": "H3"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/spec/regression/regression-suite.ts
+++ b/spec/regression/regression-suite.ts
@@ -196,11 +196,15 @@ export class RegressionSuite {
             const operationNames = operations.map(def => def.name!.value);
             actualResult = {};
             for (const operationName of operationNames) {
+                let operationContext = context;
+                if (context && context.operations && context.operations[operationName]) {
+                    operationContext = context.operations[operationName];
+                }
                 let operationResult = await graphql(
                     this.schema,
                     gqlSource,
                     {} /* root */,
-                    context,
+                    operationContext,
                     variableValues,
                     operationName
                 );

--- a/src/authorization/transformers/traversal.ts
+++ b/src/authorization/transformers/traversal.ts
@@ -1,22 +1,29 @@
-import { getEffectiveCollectSegments } from '../../model/implementation/collect-path';
-import { PERMISSION_DENIED_ERROR, QueryNode, RuntimeErrorQueryNode, TraversalQueryNode } from '../../query-tree';
+import { RelationSegment } from '../../model/implementation/collect-path';
+import {
+    PERMISSION_DENIED_ERROR,
+    QueryNode,
+    RuntimeErrorQueryNode,
+    TraversalQueryNode,
+    VariableQueryNode
+} from '../../query-tree';
 import { AccessOperation, AuthContext } from '../auth-basics';
 import { PermissionResult } from '../permission-descriptors';
-import { getPermissionDescriptorOfField, getPermissionDescriptorOfRootEntityType } from '../permission-descriptors-in-model';
+import {
+    getPermissionDescriptorOfField,
+    getPermissionDescriptorOfRootEntityType
+} from '../permission-descriptors-in-model';
 
 export function transformTraversalQueryNode(node: TraversalQueryNode, authContext: AuthContext): QueryNode {
-    const { relationSegments, fieldSegments } = getEffectiveCollectSegments(node.path);
+    const { relationSegments, fieldSegments } = node;
 
     for (const segment of relationSegments) {
         const targetType = segment.resultingType;
         const entityPermissionDescriptor = getPermissionDescriptorOfRootEntityType(targetType);
         const entityAccess = entityPermissionDescriptor.canAccess(authContext, AccessOperation.READ);
-        switch (entityAccess) {
-            case PermissionResult.DENIED:
-                return new RuntimeErrorQueryNode(`Not authorized to read ${targetType.name} objects`, { code: PERMISSION_DENIED_ERROR });
-            case PermissionResult.CONDITIONAL:
-                // no path filters yet, so we can't apply the access filter
-                return new RuntimeErrorQueryNode(`Not authorized to unconditionally read ${targetType.name} objects`, { code: PERMISSION_DENIED_ERROR });
+        if (entityAccess === PermissionResult.DENIED) {
+            return new RuntimeErrorQueryNode(`Not authorized to read ${targetType.name} objects`, {
+                code: PERMISSION_DENIED_ERROR
+            });
         }
     }
 
@@ -25,10 +32,46 @@ export function transformTraversalQueryNode(node: TraversalQueryNode, authContex
         const access = fieldPermissionDescriptor.canAccess(authContext, AccessOperation.READ);
         switch (access) {
             case PermissionResult.DENIED:
-                return new RuntimeErrorQueryNode(`Not authorized to read ${segment.field.declaringType.name}.${segment.field.name}`, { code: PERMISSION_DENIED_ERROR });
+                return new RuntimeErrorQueryNode(
+                    `Not authorized to read ${segment.field.declaringType.name}.${segment.field.name}`,
+                    { code: PERMISSION_DENIED_ERROR }
+                );
             case PermissionResult.CONDITIONAL:
-                throw new Error(`Conditional permission profiles are currently not supported on fields, but used in ${segment.field.declaringType.name}.${segment.field.name}`);
+                throw new Error(
+                    `Conditional permission profiles are currently not supported on fields, but used in ${segment.field.declaringType.name}.${segment.field.name}`
+                );
         }
+    }
+
+    let hasAppliedFilter = false;
+    const filteredRelationSegments = relationSegments.map(
+        (segment): RelationSegment => {
+            const targetType = segment.resultingType;
+            const entityPermissionDescriptor = getPermissionDescriptorOfRootEntityType(targetType);
+            const entityAccess = entityPermissionDescriptor.canAccess(authContext, AccessOperation.READ);
+            switch (entityAccess) {
+                case PermissionResult.DENIED:
+                    throw new Error(`Unexpected DENIED permission - should have been caught earlier`);
+                case PermissionResult.CONDITIONAL:
+                    const variableNode = new VariableQueryNode(targetType.name);
+                    const filter = entityPermissionDescriptor.getAccessCondition(
+                        authContext,
+                        AccessOperation.READ,
+                        variableNode
+                    );
+                    hasAppliedFilter = true;
+                    return {
+                        ...segment,
+                        vertexFilterVariable: variableNode,
+                        vertexFilter: filter
+                    };
+                default:
+                    return segment;
+            }
+        }
+    );
+    if (hasAppliedFilter) {
+        return new TraversalQueryNode(node.sourceEntityNode, filteredRelationSegments, fieldSegments);
     }
 
     return node;

--- a/src/database/inmemory/js-generator.ts
+++ b/src/database/inmemory/js-generator.ts
@@ -633,9 +633,11 @@ register(TraversalQueryNode, (node, context) => {
     let currentFrag: JSFragment = processNode(node.sourceEntityNode, context);
     let isList = false;
 
-    const { relationSegments, fieldSegments } = getEffectiveCollectSegments(node.path);
+    for (const segment of node.relationSegments) {
+        if (segment.vertexFilter) {
+            throw new Error(`@collect with accessGroup restrictions is not supported by InMemoryAdapter`);
+        }
 
-    for (const segment of relationSegments) {
         if (isList) {
             const nodeVar = js.variable('node');
             const accVar = js.variable('acc');
@@ -682,7 +684,7 @@ register(TraversalQueryNode, (node, context) => {
         }
     }
 
-    for (const segment of fieldSegments) {
+    for (const segment of node.fieldSegments) {
         if (isList) {
             if (segment.isListSegment) {
                 const nodeVar = js.variable('node');

--- a/src/query-tree/queries.ts
+++ b/src/query-tree/queries.ts
@@ -1,6 +1,6 @@
-import { CollectPath } from '../model/implementation/collect-path';
-import { blue } from '../utils/colors';
 import { Field, RelationSide, RootEntityType } from '../model';
+import { CollectPathSegment, FieldSegment, RelationSegment } from '../model/implementation/collect-path';
+import { blue } from '../utils/colors';
 import { QueryNode } from './base';
 
 export class EntityFromIdQueryNode extends QueryNode {
@@ -106,23 +106,25 @@ export class FollowEdgeQueryNode extends QueryNode {
  * Traverses a path of relations and other fields
  */
 export class TraversalQueryNode extends QueryNode {
-    constructor(readonly path: CollectPath, readonly sourceEntityNode: QueryNode) {
+    constructor(
+        readonly sourceEntityNode: QueryNode,
+        readonly relationSegments: ReadonlyArray<RelationSegment>,
+        readonly fieldSegments: ReadonlyArray<FieldSegment>
+    ) {
         super();
     }
 
     describe() {
-        return `traverse ${this.path.path} from ${this.sourceEntityNode.describe()}`;
+        const segments = [...this.relationSegments, ...this.fieldSegments];
+        return `traverse ${segments
+            .map(s => this.describeSegment(s))
+            .join('.')} from ${this.sourceEntityNode.describe()}`;
+    }
+
+    private describeSegment(segment: CollectPathSegment) {
+        if (segment.kind === 'relation') {
+            return `${segment.field.name}{${segment.minDepth},${segment.maxDepth}}`;
+        }
+        return segment.field.name;
     }
 }
-
-// Cons 1->n  Item m->n HU
-// consigment
-//   - flat: HUs
-//       - "parent": relevantItems:
-
-// consignment
-// - flat HUs (with all seletion
-// - items
-//     - hus.id
-
-//

--- a/src/schema-generation/field-nodes.ts
+++ b/src/schema-generation/field-nodes.ts
@@ -1,5 +1,6 @@
 import { AggregationOperator, RootEntityType } from '../model';
 import { Field } from '../model/implementation';
+import { getEffectiveCollectSegments } from '../model/implementation/collect-path';
 import {
     AggregationQueryNode,
     BasicType,
@@ -45,7 +46,8 @@ export function createFieldNode(
 
     if (field.collectPath) {
         if (field.aggregationOperator) {
-            let items: QueryNode = new TraversalQueryNode(field.collectPath, sourceNode);
+            const { relationSegments, fieldSegments } = getEffectiveCollectSegments(field.collectPath);
+            let items: QueryNode = new TraversalQueryNode(sourceNode, relationSegments, fieldSegments);
 
             if (field.aggregationOperator === AggregationOperator.COUNT) {
                 return new CountQueryNode(items);
@@ -70,7 +72,8 @@ export function createFieldNode(
                 (field.type.isScalarType || field.type.isEnumType);
             return new AggregationQueryNode(items, field.aggregationOperator, { sort });
         } else {
-            return new TraversalQueryNode(field.collectPath, sourceNode);
+            const { relationSegments, fieldSegments } = getEffectiveCollectSegments(field.collectPath);
+            return new TraversalQueryNode(sourceNode, relationSegments, fieldSegments);
         }
     }
 


### PR DESCRIPTION
If a user only has accessGroup-restricted access to some collections
in the path of a @collect field, this field is now evaluated as if
objects the user does not see didn't exist at all.

Previously, this failed with a static permission-denied error.