### PR TITLE
Enable CONTAINS_ANY_PREFIX in flexsearch

### DIFF
--- a/spec/regression/logistics/tests/descriptions.result.json
+++ b/spec/regression/logistics/tests/descriptions.result.json
@@ -3743,6 +3743,14 @@
                             "description": "Tokenizes the provided string into words, and checks if at least one word is not contained in `description`.\n Stemming (reduction of words on their base form) is applied."
                         },
                         {
+                            "name": "description_contains_any_prefix",
+                            "description": "Tokenizes the provided string into prefixes, and checks if `description` contains any word that starts with one of these prefixes.\n Stemming (reduction of words on their base form) is applied."
+                        },
+                        {
+                            "name": "description_not_contains_any_prefix",
+                            "description": "Tokenizes the provided string into prefixes, and checks if `description` does not contain any word that starts with one of these prefixes.\n Stemming (reduction of words on their base form) is applied."
+                        },
+                        {
                             "name": "description_contains_all_prefixes",
                             "description": "Tokenizes the provided string into prefixes, and checks if all prefixes appears in `description`.\n Stemming (reduction of words on their base form) is applied."
                         },

--- a/spec/regression/logistics/tests/flex-search.graphql
+++ b/spec/regression/logistics/tests/flex-search.graphql
@@ -1,199 +1,116 @@
-query equals{
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            deliveryNumber: "1000173"
-        }
-    ){
+query equals {
+    flexSearchDeliveries(flexSearchFilter: { deliveryNumber: "1000173" }) {
         deliveryNumber
     }
 }
 
-query equals_number{
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            aNumber: 1000521
-        }
-    ){
+query equals_number {
+    flexSearchDeliveries(flexSearchFilter: { aNumber: 1000521 }) {
         deliveryNumber
     }
 }
 
-query in{
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            deliveryNumber_in: ["1000173","1000521"]
-        }
-    ){
+query in {
+    flexSearchDeliveries(flexSearchFilter: { deliveryNumber_in: ["1000173", "1000521"] }) {
         deliveryNumber
     }
 }
 
-query starts_with{
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            deliveryNumber_starts_with: "10005"
-        }
-    ){
+query starts_with {
+    flexSearchDeliveries(flexSearchFilter: { deliveryNumber_starts_with: "10005" }) {
         deliveryNumber
     }
 }
 
-query gt_lt{
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            itemsAggregation:{
-                quantity_lt: 5
-            }
-        }
-    ){
+query gt_lt {
+    flexSearchDeliveries(flexSearchFilter: { itemsAggregation: { quantity_lt: 5 } }) {
         deliveryNumber
     }
 }
 query containsAnyWord {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            description_contains_any_word: "anyword"
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { description_contains_any_word: "anyword" }) {
         deliveryNumber
     }
 }
 query containsAllWords {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            description_contains_all_words: "all words"
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { description_contains_all_words: "all words" }) {
         deliveryNumber
     }
 }
 query containsAllPrefixes {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            description_contains_all_prefixes: "all prefixes"
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { description_contains_all_prefixes: "all prefixes" }) {
         deliveryNumber
     }
 }
+
+query containsAnyPrefix {
+    flexSearchDeliveries(flexSearchFilter: { description_contains_any_prefix: "all prefixes" }) {
+        deliveryNumber
+    }
+}
+
 query containsPhrase {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            description_contains_phrase: "a phrase"
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { description_contains_phrase: "a phrase" }) {
         deliveryNumber
     }
 }
 
 query equals_enum {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            enumFlexSearch: Foo
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { enumFlexSearch: Foo }) {
         deliveryNumber
     }
 }
 
 query valueObject {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            consignee: {
-                city: "Singapore"
-            }
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { consignee: { city: "Singapore" } }) {
         deliveryNumber
     }
 }
 
 query equals_null {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            destinationCountryISOCode: null
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { destinationCountryISOCode: null }) {
         deliveryNumber
     }
 }
 
 query filter_below_max {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            deliveryNumber: "1000521"
-        }
-        filter: {
-            id_gt: 1
-        }
-    ){
+    flexSearchDeliveries(flexSearchFilter: { deliveryNumber: "1000521" }, filter: { id_gt: 1 }) {
         deliveryNumber
     }
 }
 
 query order_below_max {
-    flexSearchDeliveries(
-        flexSearchFilter:{
-            deliveryNumber: "1000521"
-        }
-        orderBy: id_ASC
-    ){
+    flexSearchDeliveries(flexSearchFilter: { deliveryNumber: "1000521" }, orderBy: id_ASC) {
         deliveryNumber
     }
 }
 
 query filter_above_max {
-    flexSearchDeliveries(
-        filter: {
-            id_gt: 1
-        }
-    ){
+    flexSearchDeliveries(filter: { id_gt: 1 }) {
         deliveryNumber
     }
 }
 
 query order_above_max {
-    flexSearchDeliveries(
-        orderBy: id_ASC
-    ){
+    flexSearchDeliveries(orderBy: id_ASC) {
         deliveryNumber
     }
 }
 
-query expression{
-    flexSearchDeliveries(
-        flexSearchExpression: "all"
-    ){
+query expression {
+    flexSearchDeliveries(flexSearchExpression: "all") {
         deliveryNumber
     }
 }
 
-query recursion_successfull{
-    flexSearchDeliveries(
-        flexSearchFilter: {
-            recursion: {
-                recursion: {
-                    name: "test_b"
-                }
-            }
-        }
-    ){
+query recursion_successfull {
+    flexSearchDeliveries(flexSearchFilter: { recursion: { recursion: { name: "test_b" } } }) {
         deliveryNumber
     }
 }
 
-query recursion_error{
-    flexSearchDeliveries(
-        flexSearchFilter: {
-            recursion: {
-                recursion: {
-                    recursion: {
-                        name: "test_c"
-                    }
-                }
-            }
-        }
-    ){
+query recursion_error {
+    flexSearchDeliveries(flexSearchFilter: { recursion: { recursion: { recursion: { name: "test_c" } } } }) {
         deliveryNumber
     }
 }

--- a/spec/regression/logistics/tests/flex-search.result.json
+++ b/spec/regression/logistics/tests/flex-search.result.json
@@ -152,7 +152,7 @@
                 "message": "Too many objects.",
                 "locations": [
                     {
-                        "line": 157,
+                        "line": 89,
                         "column": 5
                     }
                 ],
@@ -169,7 +169,7 @@
                 "message": "Too many objects.",
                 "locations": [
                     {
-                        "line": 167,
+                        "line": 95,
                         "column": 5
                     }
                 ],
@@ -207,7 +207,7 @@
                 "message": "Recursive filters can only be defined for 1 level of recursion.",
                 "locations": [
                     {
-                        "line": 197,
+                        "line": 113,
                         "column": 5
                     }
                 ],

--- a/spec/regression/logistics/tests/flex-search.result.json
+++ b/spec/regression/logistics/tests/flex-search.result.json
@@ -1,215 +1,221 @@
 {
-  "equals": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
+    "equals": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "equals_number": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000522"
+    },
+    "equals_number": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "in": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
-        },
-        {
-          "deliveryNumber": "1000521"
+    },
+    "in": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "starts_with": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
-        },
-        {
-          "deliveryNumber": "1000522"
+    },
+    "starts_with": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                },
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "gt_lt": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
-        },
-        {
-          "deliveryNumber": "1000522"
+    },
+    "gt_lt": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "containsAnyWord": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
+    },
+    "containsAnyWord": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "containsAllWords": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "containsAllWords": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "containsAllPrefixes": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "containsAllPrefixes": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "containsPhrase": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000522"
+    },
+    "containsAnyPrefix": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "equals_enum": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
+    },
+    "containsPhrase": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "valueObject": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "equals_enum": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "equals_null": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
+    },
+    "valueObject": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "filter_below_max": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "equals_null": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "order_below_max": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "filter_below_max": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "filter_above_max": {
-    "errors": [
-      {
-        "message": "Too many objects.",
-        "locations": [
-          {
-            "line": 146,
-            "column": 5
-          }
+    },
+    "order_below_max": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
+        }
+    },
+    "filter_above_max": {
+        "errors": [
+            {
+                "message": "Too many objects.",
+                "locations": [
+                    {
+                        "line": 157,
+                        "column": 5
+                    }
+                ],
+                "path": ["flexSearchDeliveries"]
+            }
         ],
-        "path": [
-          "flexSearchDeliveries"
-        ]
-      }
-    ],
-    "data": {
-      "flexSearchDeliveries": null
-    }
-  },
-  "order_above_max": {
-    "errors": [
-      {
-        "message": "Too many objects.",
-        "locations": [
-          {
-            "line": 156,
-            "column": 5
-          }
-        ],
-        "path": [
-          "flexSearchDeliveries"
-        ]
-      }
-    ],
-    "data": {
-      "flexSearchDeliveries": null
-    }
-  },
-  "expression": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
-        },
-        {
-          "deliveryNumber": "1000521"
+        "data": {
+            "flexSearchDeliveries": null
         }
-      ]
-    }
-  },
-  "recursion_successfull": {
-    "data": {
-      "flexSearchDeliveries": [
-        {
-          "deliveryNumber": "1000173"
-        }
-      ]
-    }
-  },
-  "recursion_error": {
-    "errors": [
-      {
-        "message": "Recursive filters can only be defined for 1 level of recursion.",
-        "locations": [
-          {
-            "line": 186,
-            "column": 5
-          }
+    },
+    "order_above_max": {
+        "errors": [
+            {
+                "message": "Too many objects.",
+                "locations": [
+                    {
+                        "line": 167,
+                        "column": 5
+                    }
+                ],
+                "path": ["flexSearchDeliveries"]
+            }
         ],
-        "path": [
-          "flexSearchDeliveries"
-        ]
-      }
-    ],
-    "data": {
-      "flexSearchDeliveries": null
+        "data": {
+            "flexSearchDeliveries": null
+        }
+    },
+    "expression": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
+        }
+    },
+    "recursion_successfull": {
+        "data": {
+            "flexSearchDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
+        }
+    },
+    "recursion_error": {
+        "errors": [
+            {
+                "message": "Recursive filters can only be defined for 1 level of recursion.",
+                "locations": [
+                    {
+                        "line": 197,
+                        "column": 5
+                    }
+                ],
+                "path": ["flexSearchDeliveries"]
+            }
+        ],
+        "data": {
+            "flexSearchDeliveries": null
+        }
     }
-  }
 }

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -1,15 +1,15 @@
-import { AggregationOperator, Field, FlexSearchLanguage, Relation, RootEntityType } from '../../model';
-import { FieldSegment, getEffectiveCollectSegments, RelationSegment } from '../../model/implementation/collect-path';
+import { AggregationOperator, Field, Relation, RootEntityType } from '../../model';
+import { FieldSegment, RelationSegment } from '../../model/implementation/collect-path';
 import {
     AddEdgesQueryNode,
     AggregationQueryNode,
-    ConfirmForBillingQueryNode,
     BasicType,
     BinaryOperationQueryNode,
     BinaryOperator,
     BinaryOperatorWithLanguage,
     ConcatListsQueryNode,
     ConditionalQueryNode,
+    ConfirmForBillingQueryNode,
     ConstBoolQueryNode,
     ConstIntQueryNode,
     CountQueryNode,
@@ -400,6 +400,7 @@ register(FlexSearchQueryNode, (node, context) => {
         aql`FOR ${itemContext.getVariable(node.itemVariable)}`,
         aql`IN ${aql.identifier(getFlexSearchViewNameForRootEntity(node.rootEntityType!))}`,
         aql`SEARCH ${processNode(node.flexFilterNode, itemContext)}`,
+        node.isOptimisationsDisabled ? aql`OPTIONS { conditionOptimization: 'none' }` : aql``,
         aql`RETURN ${itemContext.getVariable(node.itemVariable)}`
     );
 });

--- a/src/model/implementation/root-entity-type.ts
+++ b/src/model/implementation/root-entity-type.ts
@@ -2,7 +2,6 @@ import { GraphQLID, GraphQLString } from 'graphql';
 import memorize from 'memorize-decorator';
 import {
     ACCESS_GROUP_FIELD,
-    DEFAULT_PERMISSION_PROFILE,
     FLEX_SEARCH_FULLTEXT_INDEXED_DIRECTIVE,
     FLEX_SEARCH_INDEXED_DIRECTIVE,
     FLEX_SEARCH_ORDER_ARGUMENT,
@@ -97,7 +96,10 @@ export class RootEntityType extends ObjectTypeBase {
     }
 
     get hasFieldsIncludedInSearch() {
-        return this.fields.some(value => value.isIncludedInSearch);
+        return (
+            this.fields.some(value => value.isIncludedInSearch) ||
+            this.fields.some(value => value.isFulltextIncludedInSearch)
+        );
     }
 
     @memorize()

--- a/src/query-tree/flex-search.ts
+++ b/src/query-tree/flex-search.ts
@@ -15,16 +15,19 @@ export class FlexSearchQueryNode extends QueryNode {
     public readonly flexFilterNode: QueryNode;
     public readonly rootEntityType: RootEntityType;
     public readonly itemVariable: VariableQueryNode;
+    public readonly isOptimisationsDisabled: boolean;
 
     constructor(params: {
         rootEntityType: RootEntityType;
         flexFilterNode?: QueryNode;
         itemVariable?: VariableQueryNode;
+        isOptimisationsDisabled?: boolean;
     }) {
         super();
         this.flexFilterNode = params.flexFilterNode || new ConstBoolQueryNode(true);
         this.itemVariable = params.itemVariable || new VariableQueryNode(decapitalize(params.rootEntityType.name));
         this.rootEntityType = params.rootEntityType;
+        this.isOptimisationsDisabled = params.isOptimisationsDisabled || false;
     }
 
     describe(): string {
@@ -45,8 +48,8 @@ export class FlexSearchQueryNode extends QueryNode {
 export class FlexSearchComplexOperatorQueryNode extends QueryNode {
     constructor(
         readonly expression: string,
-        private readonly comparisonOperator: BinaryOperatorWithLanguage,
-        private readonly logicalOperator: BinaryOperator,
+        readonly comparisonOperator: BinaryOperatorWithLanguage,
+        readonly logicalOperator: BinaryOperator,
         private readonly fieldNode: QueryNode,
         readonly flexSearchLanguage: FlexSearchLanguage
     ) {

--- a/src/query-tree/flex-search.ts
+++ b/src/query-tree/flex-search.ts
@@ -1,6 +1,6 @@
 import { FlexSearchLanguage } from '../model/config';
 import { RootEntityType } from '../model/implementation';
-import { and } from '../schema-generation/utils/input-types';
+import { binaryOp } from '../schema-generation/utils/input-types';
 import { decapitalize, indent } from '../utils/utils';
 import { QueryNode } from './base';
 import { ConstBoolQueryNode, LiteralQueryNode } from './literals';
@@ -12,15 +12,14 @@ import { VariableQueryNode } from './variables';
  * A QueryNode that represents a FlexSearch Query on a RootEntity Type
  */
 export class FlexSearchQueryNode extends QueryNode {
-
     public readonly flexFilterNode: QueryNode;
     public readonly rootEntityType: RootEntityType;
     public readonly itemVariable: VariableQueryNode;
 
     constructor(params: {
-        rootEntityType: RootEntityType,
-        flexFilterNode?: QueryNode,
-        itemVariable?: VariableQueryNode
+        rootEntityType: RootEntityType;
+        flexFilterNode?: QueryNode;
+        itemVariable?: VariableQueryNode;
     }) {
         super();
         this.flexFilterNode = params.flexFilterNode || new ConstBoolQueryNode(true);
@@ -29,12 +28,14 @@ export class FlexSearchQueryNode extends QueryNode {
     }
 
     describe(): string {
-        return `Use FlexSearch for ${this.rootEntityType!.name}`
-            + ` with ${this.itemVariable.describe()} => \n` + indent(
-                (this.flexFilterNode.equals(ConstBoolQueryNode.TRUE) ? '' : `where ${this.flexFilterNode.describe()}\n`)
-            );
+        return (
+            `Use FlexSearch for ${this.rootEntityType!.name}` +
+            ` with ${this.itemVariable.describe()} => \n` +
+            indent(
+                this.flexFilterNode.equals(ConstBoolQueryNode.TRUE) ? '' : `where ${this.flexFilterNode.describe()}\n`
+            )
+        );
     }
-
 }
 
 /**
@@ -42,13 +43,13 @@ export class FlexSearchQueryNode extends QueryNode {
  * to tokenize the search expression, before the sub-tree for this expression can be built.
  */
 export class FlexSearchComplexOperatorQueryNode extends QueryNode {
-
     constructor(
         readonly expression: string,
         private readonly comparisonOperator: BinaryOperatorWithLanguage,
         private readonly logicalOperator: BinaryOperator,
         private readonly fieldNode: QueryNode,
-        readonly flexSearchLanguage: FlexSearchLanguage) {
+        readonly flexSearchLanguage: FlexSearchLanguage
+    ) {
         super();
     }
 
@@ -57,22 +58,33 @@ export class FlexSearchComplexOperatorQueryNode extends QueryNode {
     }
 
     expand(tokenizations: ReadonlyArray<FlexSearchTokenization>): QueryNode {
-        const tokenization = tokenizations.find(value => value.expression === this.expression && value.language === this.flexSearchLanguage);
+        const tokenization = tokenizations.find(
+            value => value.expression === this.expression && value.language === this.flexSearchLanguage
+        );
         const tokens = tokenization ? tokenization.tokens : [];
-        const neutralOperand = this.logicalOperator === BinaryOperator.AND ? ConstBoolQueryNode.TRUE : ConstBoolQueryNode.FALSE;
-        return simplifyBooleans(tokens
-            .map(value => new OperatorWithLanguageQueryNode(this.fieldNode, this.comparisonOperator, new LiteralQueryNode(value), this.flexSearchLanguage) as QueryNode)
-            .reduce(and, neutralOperand));
+        const neutralOperand =
+            this.logicalOperator === BinaryOperator.AND ? ConstBoolQueryNode.TRUE : ConstBoolQueryNode.FALSE;
+        return simplifyBooleans(
+            tokens
+                .map(
+                    value =>
+                        new OperatorWithLanguageQueryNode(
+                            this.fieldNode,
+                            this.comparisonOperator,
+                            new LiteralQueryNode(value),
+                            this.flexSearchLanguage
+                        ) as QueryNode
+                )
+                .reduce(binaryOp(this.logicalOperator), neutralOperand)
+        );
     }
-
 }
 
 export interface FlexSearchTokenization {
-    expression: string
-    language: FlexSearchLanguage
-    tokens: ReadonlyArray<string>
+    expression: string;
+    language: FlexSearchLanguage;
+    tokens: ReadonlyArray<string>;
 }
-
 
 /**
  * A node that performs an EXISTS Check
@@ -83,7 +95,9 @@ export class FlexSearchFieldExistsQueryNode extends QueryNode {
     }
 
     describe() {
-        return `EXISTS(${this.sourceNode.describe()}, ${this.flexSearchLanguage ? this.flexSearchLanguage.toString() : 'identity'})`;
+        return `EXISTS(${this.sourceNode.describe()}, ${
+            this.flexSearchLanguage ? this.flexSearchLanguage.toString() : 'identity'
+        })`;
     }
 }
 
@@ -91,11 +105,17 @@ export class FlexSearchFieldExistsQueryNode extends QueryNode {
  * A node that performs a FlexSearch STARTS_WITH Operation
  */
 export class FlexSearchStartsWithQueryNode extends QueryNode {
-    constructor(public readonly lhs: QueryNode, public readonly rhs: QueryNode, public readonly flexSearchLanguage?: FlexSearchLanguage) {
+    constructor(
+        public readonly lhs: QueryNode,
+        public readonly rhs: QueryNode,
+        public readonly flexSearchLanguage?: FlexSearchLanguage
+    ) {
         super();
     }
 
     describe() {
-        return `STARTS_WITH(${this.lhs.describe()},${this.rhs.describe()}, ${this.flexSearchLanguage ? this.flexSearchLanguage.toString() : 'identity'})`;
+        return `STARTS_WITH(${this.lhs.describe()},${this.rhs.describe()}, ${
+            this.flexSearchLanguage ? this.flexSearchLanguage.toString() : 'identity'
+        })`;
     }
 }

--- a/src/schema-generation/flex-search-filter-input-types/constants.ts
+++ b/src/schema-generation/flex-search-filter-input-types/constants.ts
@@ -1,17 +1,45 @@
 import { GraphQLBoolean, GraphQLFloat, GraphQLID, GraphQLInt, GraphQLString } from 'graphql';
 import { FlexSearchLanguage } from '../../model/config';
 import { BinaryOperator, QueryNode } from '../../query-tree';
-import { INPUT_FIELD_CONTAINS_ALL_PREFIXES, INPUT_FIELD_CONTAINS_ALL_WORDS, INPUT_FIELD_CONTAINS_ANY_PREFIX, INPUT_FIELD_CONTAINS_ANY_WORD, INPUT_FIELD_CONTAINS_PHRASE, INPUT_FIELD_ENDS_WITH, INPUT_FIELD_EQUAL, INPUT_FIELD_GT, INPUT_FIELD_GTE, INPUT_FIELD_IN, INPUT_FIELD_LT, INPUT_FIELD_LTE, INPUT_FIELD_NOT, INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES, INPUT_FIELD_NOT_CONTAINS_ALL_WORDS, INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX, INPUT_FIELD_NOT_CONTAINS_ANY_WORD, INPUT_FIELD_NOT_CONTAINS_PHRASE, INPUT_FIELD_NOT_ENDS_WITH, INPUT_FIELD_NOT_IN, INPUT_FIELD_NOT_STARTS_WITH, INPUT_FIELD_STARTS_WITH } from '../../schema/constants';
+import {
+    INPUT_FIELD_CONTAINS_ALL_PREFIXES,
+    INPUT_FIELD_CONTAINS_ALL_WORDS,
+    INPUT_FIELD_CONTAINS_ANY_PREFIX,
+    INPUT_FIELD_CONTAINS_ANY_WORD,
+    INPUT_FIELD_CONTAINS_PHRASE,
+    INPUT_FIELD_ENDS_WITH,
+    INPUT_FIELD_EQUAL,
+    INPUT_FIELD_GT,
+    INPUT_FIELD_GTE,
+    INPUT_FIELD_IN,
+    INPUT_FIELD_LT,
+    INPUT_FIELD_LTE,
+    INPUT_FIELD_NOT,
+    INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES,
+    INPUT_FIELD_NOT_CONTAINS_ALL_WORDS,
+    INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX,
+    INPUT_FIELD_NOT_CONTAINS_ANY_WORD,
+    INPUT_FIELD_NOT_CONTAINS_PHRASE,
+    INPUT_FIELD_NOT_ENDS_WITH,
+    INPUT_FIELD_NOT_IN,
+    INPUT_FIELD_NOT_STARTS_WITH,
+    INPUT_FIELD_STARTS_WITH
+} from '../../schema/constants';
 import { GraphQLDateTime } from '../../schema/scalars/date-time';
 import { GraphQLLocalDate } from '../../schema/scalars/local-date';
 import { GraphQLLocalTime } from '../../schema/scalars/local-time';
 import { NUMERIC_FILTER_FIELDS } from '../filter-input-types/constants';
 import { binaryNotOp, binaryOp, notStartsWithOp, startsWithOp } from '../utils/input-types';
 
-
 export const SOME_PREFIX = 'some';
 
-export const FLEX_SEARCH_FILTER_OPERATORS: { [suffix: string]: (fieldNode: QueryNode, valueNode: QueryNode, flexSearchLanguage?: FlexSearchLanguage) => QueryNode } = {
+export const FLEX_SEARCH_FILTER_OPERATORS: {
+    [suffix: string]: (
+        fieldNode: QueryNode,
+        valueNode: QueryNode,
+        flexSearchLanguage?: FlexSearchLanguage
+    ) => QueryNode;
+} = {
     [INPUT_FIELD_EQUAL]: binaryOp(BinaryOperator.EQUAL),
     [INPUT_FIELD_NOT]: binaryOp(BinaryOperator.UNEQUAL),
     [INPUT_FIELD_LT]: binaryOp(BinaryOperator.LESS_THAN),
@@ -24,7 +52,6 @@ export const FLEX_SEARCH_FILTER_OPERATORS: { [suffix: string]: (fieldNode: Query
     [INPUT_FIELD_NOT_STARTS_WITH]: notStartsWithOp(),
     [INPUT_FIELD_ENDS_WITH]: binaryOp(BinaryOperator.ENDS_WITH),
     [INPUT_FIELD_NOT_ENDS_WITH]: binaryNotOp(BinaryOperator.ENDS_WITH)
-
 };
 
 export const STRING_FLEX_SEARCH_FILTER_FIELDS = [
@@ -41,20 +68,15 @@ export const STRING_TEXT_ANALYZER_FILTER_FIELDS = [
     INPUT_FIELD_NOT_CONTAINS_ANY_WORD,
     INPUT_FIELD_CONTAINS_ALL_WORDS,
     INPUT_FIELD_NOT_CONTAINS_ALL_WORDS,
-    // INPUT_FIELD_CONTAINS_ANY_PREFIX,
-    // INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX,
+    INPUT_FIELD_CONTAINS_ANY_PREFIX,
+    INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX,
     INPUT_FIELD_CONTAINS_ALL_PREFIXES,
     INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES,
     INPUT_FIELD_CONTAINS_PHRASE,
     INPUT_FIELD_NOT_CONTAINS_PHRASE
 ];
 
-const ID_FLEX_SEARCH_FILTER_FIELDS = [
-    INPUT_FIELD_EQUAL,
-    INPUT_FIELD_NOT,
-    INPUT_FIELD_IN,
-    INPUT_FIELD_NOT_IN
-];
+const ID_FLEX_SEARCH_FILTER_FIELDS = [INPUT_FIELD_EQUAL, INPUT_FIELD_NOT, INPUT_FIELD_IN, INPUT_FIELD_NOT_IN];
 
 export const FLEX_SEARCH_FILTER_FIELDS_BY_TYPE: { [name: string]: string[] } = {
     [GraphQLString.name]: STRING_FLEX_SEARCH_FILTER_FIELDS,
@@ -85,33 +107,43 @@ export const FLEX_SEARCH_FILTER_DESCRIPTIONS: { [name: string]: string | { [type
     [INPUT_FIELD_GT]: 'Checks if $field is greater than a specified value.',
     [INPUT_FIELD_GTE]: 'Checks if $field is greater or equal a specified value.',
 
-
     [INPUT_FIELD_STARTS_WITH]: 'Checks if $field starts with a specified string, case-insensitively.',
     [INPUT_FIELD_NOT_STARTS_WITH]: 'Checks if $field does not start with a specified string, case-insensitively.',
-    [INPUT_FIELD_CONTAINS_ANY_WORD]: 'Tokenizes the provided string into words, and checks if $field contains at least one of them.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ANY_WORD]: 'Tokenizes the provided string into words, and checks if $field contains none of them.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ALL_WORDS]: 'Tokenizes the provided string into words, and checks if $field contains all of them.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ALL_WORDS]: 'Tokenizes the provided string into words, and checks if at least one word is not contained in $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ANY_PREFIX]: 'Tokenizes the provided string into prefixes, and checks if $field contains any word that starts with one of these prefixes.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX]: 'Tokenizes the provided string into prefixes, and checks if $field does not contain any word that starts with one of these prefixes.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ALL_PREFIXES]: 'Tokenizes the provided string into prefixes, and checks if all prefixes appears in $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES]: 'Tokenizes the provided prefixes into words, and checks if there is at least one prefix that does not appear in $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_PHRASE]: 'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is included in $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_PHRASE]: 'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is not included in $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.'
-
+    [INPUT_FIELD_CONTAINS_ANY_WORD]:
+        'Tokenizes the provided string into words, and checks if $field contains at least one of them.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ANY_WORD]:
+        'Tokenizes the provided string into words, and checks if $field contains none of them.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ALL_WORDS]:
+        'Tokenizes the provided string into words, and checks if $field contains all of them.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ALL_WORDS]:
+        'Tokenizes the provided string into words, and checks if at least one word is not contained in $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ANY_PREFIX]:
+        'Tokenizes the provided string into prefixes, and checks if $field contains any word that starts with one of these prefixes.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX]:
+        'Tokenizes the provided string into prefixes, and checks if $field does not contain any word that starts with one of these prefixes.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ALL_PREFIXES]:
+        'Tokenizes the provided string into prefixes, and checks if all prefixes appears in $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES]:
+        'Tokenizes the provided prefixes into words, and checks if there is at least one prefix that does not appear in $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_PHRASE]:
+        'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is included in $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_PHRASE]:
+        'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is not included in $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.'
 };
 
-export const FLEX_SEARCH_FILTER_DESCRIPTIONS_AGGREGATION: { [name: string]: string | { [typeName: string]: string } } = {
+export const FLEX_SEARCH_FILTER_DESCRIPTIONS_AGGREGATION: {
+    [name: string]: string | { [typeName: string]: string };
+} = {
     [INPUT_FIELD_EQUAL]: {
         [GraphQLString.name]: 'Checks if any value in $field equals a specified string, case-insensitively.\n\n',
         ['']: 'Checks if $field equals a specified value.'
@@ -123,7 +155,8 @@ export const FLEX_SEARCH_FILTER_DESCRIPTIONS_AGGREGATION: { [name: string]: stri
     },
 
     [INPUT_FIELD_STARTS_WITH]: 'Checks if any value in $field starts with a specified string, case-insensitively.',
-    [INPUT_FIELD_NOT_STARTS_WITH]: 'Checks if none of the values in $field start with a specified string, case-insensitively.',
+    [INPUT_FIELD_NOT_STARTS_WITH]:
+        'Checks if none of the values in $field start with a specified string, case-insensitively.',
 
     [INPUT_FIELD_IN]: 'Checks if $field is contained in a specified list.',
     [INPUT_FIELD_NOT_IN]: 'Checks if $field is not contained in a specified list.',
@@ -132,29 +165,38 @@ export const FLEX_SEARCH_FILTER_DESCRIPTIONS_AGGREGATION: { [name: string]: stri
     [INPUT_FIELD_GT]: 'Checks if $field is greater then a specified value.',
     [INPUT_FIELD_GTE]: 'Checks if $field is greater or equal a specified value.',
 
-    [INPUT_FIELD_CONTAINS_ANY_WORD]: 'Tokenizes the provided string into words, and checks if any value in $field contains at least one of them.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ANY_WORD]: 'Tokenizes the provided string into words, and checks if none of the values in $field contain any of them.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ALL_WORDS]: 'Tokenizes the provided string into words, and checks if $field contains all of them in any value. ' +
-    'The words do not have to appear in the same value, but each word can appear in a different value of this list.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ALL_WORDS]: 'Tokenizes the provided string into words, and checks if at least one word is not contained in any value of $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ANY_PREFIX]: 'Tokenizes the provided string into prefixes, and checks if any value in $field contains any word that starts with one of these prefixes.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX]: 'Tokenizes the provided string into prefixes, and checks if no value in $field contains any word that starts with one of these prefixes.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_ALL_PREFIXES]: 'Tokenizes the provided string into prefixes, and checks if all prefixes appears in any value of $field.\n ' +
-    'The prefixes do not have to appear in the same value, but each prefix can appear in a different value of this list.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES]: 'Tokenizes the provided prefixes into words, and checks if there is at least one prefix that does not appear in any value of $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_CONTAINS_PHRASE]: 'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is included in any value of $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.',
-    [INPUT_FIELD_NOT_CONTAINS_PHRASE]: 'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is not included in any value of $field.\n ' +
-    'Stemming (reduction of words on their base form) is applied.'
-
+    [INPUT_FIELD_CONTAINS_ANY_WORD]:
+        'Tokenizes the provided string into words, and checks if any value in $field contains at least one of them.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ANY_WORD]:
+        'Tokenizes the provided string into words, and checks if none of the values in $field contain any of them.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ALL_WORDS]:
+        'Tokenizes the provided string into words, and checks if $field contains all of them in any value. ' +
+        'The words do not have to appear in the same value, but each word can appear in a different value of this list.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ALL_WORDS]:
+        'Tokenizes the provided string into words, and checks if at least one word is not contained in any value of $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ANY_PREFIX]:
+        'Tokenizes the provided string into prefixes, and checks if any value in $field contains any word that starts with one of these prefixes.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ANY_PREFIX]:
+        'Tokenizes the provided string into prefixes, and checks if no value in $field contains any word that starts with one of these prefixes.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_ALL_PREFIXES]:
+        'Tokenizes the provided string into prefixes, and checks if all prefixes appears in any value of $field.\n ' +
+        'The prefixes do not have to appear in the same value, but each prefix can appear in a different value of this list.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_ALL_PREFIXES]:
+        'Tokenizes the provided prefixes into words, and checks if there is at least one prefix that does not appear in any value of $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_CONTAINS_PHRASE]:
+        'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is included in any value of $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.',
+    [INPUT_FIELD_NOT_CONTAINS_PHRASE]:
+        'Tokenizes the provided string into words, and checks if that exact phrase (those words in excactly this order) is not included in any value of $field.\n ' +
+        'Stemming (reduction of words on their base form) is applied.'
 };
 
 export const FLEX_SEARCH_OPERATORS_WITH_LIST_OPERAND = [INPUT_FIELD_IN, INPUT_FIELD_NOT_IN];


### PR DESCRIPTION
We can now enable CONTAINS_ANY_PREFIX because the performance problem formerly associated with it can now mitigated by disabling condition optimization. The problem was that expressions in CNF form take ArangoDB exponentially long to optimize. Disabling the optimization fixes this problem.