### PR TITLE
fix(deps): update graphql peerDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "yaml-ast-parser": "0.0.43"
     },
     "peerDependencies": {
-        "graphql": "^14.0.0"
+        "graphql": "^14.0.0 || ^15.0.0"
     },
     "nyc": {
         "include": [


### PR DESCRIPTION
Update `graphql` peer dependency

I'm not sure if both versions are compatible, though