### PR TITLE
Fix using keywords as identifiers

### DIFF
--- a/spec/database/arangodb/aql.spec.ts
+++ b/spec/database/arangodb/aql.spec.ts
@@ -32,11 +32,7 @@ describe('aql', () => {
     });
 
     it('can join lines', () => {
-        const fragment = aql.lines(
-            aql`{`,
-            aql`  flag: ${true}`,
-            aql`}`
-        );
+        const fragment = aql.lines(aql`{`, aql`  flag: ${true}`, aql`}`);
         expect(fragment.getCode().code).to.equal('{\n  flag: @var1\n}');
         expect(fragment.toString()).to.equal('{\n  flag: true\n}');
         console.log(fragment.toColoredString());
@@ -44,10 +40,7 @@ describe('aql', () => {
 
     it('can indent lines', () => {
         const items = [123, 456, 42].map(number => aql`2 * ${number}`);
-        const fragment = aql.lines(
-            aql`[`,
-            aql.indent(aql.join(items, aql`,\n`)),
-            aql`]`);
+        const fragment = aql.lines(aql`[`, aql.indent(aql.join(items, aql`,\n`)), aql`]`);
         const oldValue = aqlConfig.enableIndentationForCode;
         aqlConfig.enableIndentationForCode = true;
         expect(fragment.getCode().code).to.equal('[\n  2 * @var1,\n  2 * @var2,\n  2 * @var3\n]');
@@ -78,12 +71,14 @@ describe('aql', () => {
         const tmp1 = new AQLVariable('label');
         const tmp2 = new AQLVariable('label');
         const fragment = aql`LET ${tmp1} = [ 1, 2, 3] FOR ${tmp2} IN ${tmp1} RETURN ${tmp2} * 2`;
-        expect(fragment.getCode().code).to.equal(`LET v_label1 = [ 1, 2, 3] FOR v_label2 IN v_label1 RETURN v_label2 * 2`);
+        expect(fragment.getCode().code).to.equal(
+            `LET v_label1 = [ 1, 2, 3] FOR v_label2 IN v_label1 RETURN v_label2 * 2`
+        );
     });
 
     describe('collection', () => {
         it('accepts normal names', () => {
-            expect(aql.collection('deliveries').getCode().code).to.equal('deliveries');
+            expect(aql.collection('deliveries').getCode().code).to.equal('@@deliveries');
         });
 
         it('rejects strange collection names', () => {

--- a/spec/regression/initialization.ts
+++ b/spec/regression/initialization.ts
@@ -48,6 +48,12 @@ export interface TestDataEnvironment {
 }
 
 export async function initTestData(path: string, schema: GraphQLSchema): Promise<TestDataEnvironment> {
+    if (!fs.existsSync(path)) {
+        return {
+            fillTemplateStrings: a => a
+        };
+    }
+
     const testData = JSON.parse(stripJsonComments(fs.readFileSync(path, 'utf-8')));
     const ids = new Map<string, string>();
 

--- a/spec/regression/keywords/default-context.json
+++ b/spec/regression/keywords/default-context.json
@@ -1,0 +1,3 @@
+{
+    "authRoles": ["allusers"]
+}

--- a/spec/regression/keywords/model/model.graphqls
+++ b/spec/regression/keywords/model/model.graphqls
@@ -1,0 +1,3 @@
+type Value @rootEntity @roles(readWrite: "allusers") {
+    limit: Int
+}

--- a/spec/regression/keywords/tests/escaped-keywords.graphql
+++ b/spec/regression/keywords/tests/escaped-keywords.graphql
@@ -1,0 +1,11 @@
+mutation m {
+    createValues(input: { limit: 10 }) {
+        limit
+    }
+}
+
+query q {
+    allValues(filter: { limit: 10 }, orderBy: limit_ASC) {
+        limit
+    }
+}

--- a/spec/regression/keywords/tests/escaped-keywords.result.json
+++ b/spec/regression/keywords/tests/escaped-keywords.result.json
@@ -1,0 +1,20 @@
+{
+    "m": {
+        "data": {
+            "createValues": [
+                {
+                    "limit": 10
+                }
+            ]
+        }
+    },
+    "q": {
+        "data": {
+            "allValues": [
+                {
+                    "limit": 10
+                }
+            ]
+        }
+    }
+}

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -274,7 +274,9 @@ const inFlexSearchFilterSymbol = Symbol('inFlexSearchFilter');
 namespace aqlExt {
     export function safeJSONKey(key: string): AQLFragment {
         if (aql.isSafeIdentifier(key)) {
-            return aql`${aql.string(key)}`; // if safe, use "name" approach
+            // we could always collide with a (future) keyword, so use "name" syntax instead of identifier
+            // ("" looks more natural than `` in json keys)
+            return aql`${aql.string(key)}`;
         } else {
             return aql`${key}`; // fall back to bound values
         }


### PR DESCRIPTION
Identifiers are now quoted in `` to avoid collisions with keywords.

Collection names are bound with @@collection to avoid collisions with other global identifiers. This probably has not been a real problem because functions are in a different namespace (they require the fn() syntax to be recognized as functions), but this avoids problems with potential global variables.