### PR TITLE
Optimize simple some/every/none filters

### DIFF
--- a/spec/regression/logistics/tests/filter-quantifiers.graphql
+++ b/spec/regression/logistics/tests/filter-quantifiers.graphql
@@ -1,17 +1,71 @@
 query some {
-    allDeliveries(filter:{items_some: { quantity_gt: 10 }}, orderBy: deliveryNumber_ASC) {
+    allDeliveries(filter: { items_some: { quantity_gt: 10 } }, orderBy: deliveryNumber_ASC) {
         deliveryNumber
     }
 }
 
 query every {
-    allDeliveries(filter:{items_every: { quantity_gt: 10 }}, orderBy: deliveryNumber_ASC) {
+    allDeliveries(filter: { items_every: { quantity_gt: 10 } }, orderBy: deliveryNumber_ASC) {
         deliveryNumber
     }
 }
 
 query none {
-    allDeliveries(filter:{items_none: { quantity_gt: 10 }}, orderBy: deliveryNumber_ASC) {
+    allDeliveries(filter: { items_none: { quantity_gt: 10 } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+# uses special optimization with IN and array expansion
+query some_equals {
+    allDeliveries(filter: { items_some: { quantity: 13 } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+# should not use said optimization
+query every_equals {
+    allDeliveries(filter: { items_every: { quantity: 13 } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+# can be simplified to equals
+query some_like_simple {
+    allDeliveries(filter: { items_some: { itemNumber_like: "1001" } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+query some_like_complicated {
+    allDeliveries(filter: { items_some: { itemNumber_like: "2%" } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+# can't use any of the optimizations because it uses multiple filters in one object
+query some_multiple {
+    allDeliveries(filter: { items_some: { quantity_gt: 7, quantity_lt: 15 } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+# should find all because a list that's null is a list that's empty, so all items match anything
+query null_list {
+    allDeliveries(filter: { serialNumbers_every: { equal: "doesnotexist" } }, orderBy: deliveryNumber_ASC) {
+        deliveryNumber
+    }
+}
+
+mutation set_empty_list {
+    updateDelivery(input: { id: "@{ids/Delivery/1}", serialNumbers: [] }) {
+        deliveryNumber
+    }
+}
+
+# should find all because a list that's null is a list that's empty, so all items match anything
+query empty_list {
+    allDeliveries(filter: { serialNumbers_every: { equal: "doesnotexist" } }, orderBy: deliveryNumber_ASC) {
         deliveryNumber
     }
 }

--- a/spec/regression/logistics/tests/filter-quantifiers.result.json
+++ b/spec/regression/logistics/tests/filter-quantifiers.result.json
@@ -1,32 +1,113 @@
 {
-  "some": {
-    "data": {
-      "allDeliveries": [
-        {
-          "deliveryNumber": "1000521"
-        },
-        {
-          "deliveryNumber": "1000522"
+    "some": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                },
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "every": {
-    "data": {
-      "allDeliveries": [
-        {
-          "deliveryNumber": "1000521"
+    },
+    "every": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
         }
-      ]
-    }
-  },
-  "none": {
-    "data": {
-      "allDeliveries": [
-        {
-          "deliveryNumber": "1000173"
+    },
+    "none": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
         }
-      ]
+    },
+    "some_equals": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
+        }
+    },
+    "every_equals": {
+        "data": {
+            "allDeliveries": []
+        }
+    },
+    "some_like_simple": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                }
+            ]
+        }
+    },
+    "some_like_complicated": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
+        }
+    },
+    "some_multiple": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                }
+            ]
+        }
+    },
+    "null_list": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                },
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
+        }
+    },
+    "set_empty_list": {
+        "data": {
+            "updateDelivery": {
+                "deliveryNumber": "1000173"
+            }
+        }
+    },
+    "empty_list": {
+        "data": {
+            "allDeliveries": [
+                {
+                    "deliveryNumber": "1000173"
+                },
+                {
+                    "deliveryNumber": "1000521"
+                },
+                {
+                    "deliveryNumber": "1000522"
+                }
+            ]
+        }
     }
-  }
 }


### PR DESCRIPTION
Filters like list_every { field_gt: 5 } now use array comparison operators (e.g. list[*].field ALL > 5). ArangoDB executs this filter faster and enables early pruning in some cases.