### PR TITLE
Do not deprecate filter arg on flexSearch yet

### DIFF
--- a/src/schema-generation/flex-search-post-filter-augmentation.ts
+++ b/src/schema-generation/flex-search-post-filter-augmentation.ts
@@ -27,7 +27,7 @@ export class FlexSearchPostFilterAugmentation {
             args: {
                 ...schemaField.args,
                 [FILTER_ARG]: {
-                    deprecationReason: `Renamed to postFilter. Use postFilter instead.`,
+                    description: `Renamed to postFilter. Use postFilter instead.`,
                     type: filterType.getInputType()
                 },
                 [POST_FILTER_ARG]: {


### PR DESCRIPTION
Deprecated arguments are a relatively new feature (requires GraphQL 15). The introspection query does not return deprecated arguments by default, so GraphQL middlewares like graphql-broker omit deprecated argument fields if they are still on GraphQL 14.

The field will be deprecated again in a future version.