### PR TITLE
Fix index creation for TTL fields with dots

### DIFF
--- a/src/model/config/indices.ts
+++ b/src/model/config/indices.ts
@@ -2,6 +2,9 @@ import { DirectiveNode, ObjectValueNode, StringValueNode } from 'graphql';
 
 export interface IndexDefinitionConfig {
     readonly id?: string;
+    /**
+     * A list of dot-separated fields that make up this index
+     */
     readonly fields: ReadonlyArray<string>;
     readonly fieldASTNodes?: ReadonlyArray<StringValueNode | DirectiveNode | undefined>;
     readonly unique?: boolean;

--- a/src/model/implementation/root-entity-type.ts
+++ b/src/model/implementation/root-entity-type.ts
@@ -72,7 +72,7 @@ export class RootEntityType extends ObjectTypeBase {
         }
 
         for (const timeToLiveType of this.timeToLiveTypes) {
-            indexConfigs.push({ unique: false, fields: timeToLiveType.input.dateField.split('.') });
+            indexConfigs.push({ unique: false, fields: [timeToLiveType.input.dateField] });
         }
 
         const indices = indexConfigs.map(config => new Index(config, this));


### PR DESCRIPTION
Index fields are actually a list of field paths, and we need one index field (the query will include one filter on the date field).