### PR TITLE
Deprecate IndexDefinition.id and prepare name

### DIFF
--- a/spec/model/create-model.spec.ts
+++ b/spec/model/create-model.spec.ts
@@ -41,9 +41,9 @@ describe('createModel', () => {
             type Test
                 @rootEntity(
                     indices: [
-                        { id: "a", fields: "test" }
-                        { id: "b", fields: ["test", "id"], unique: true }
-                        { id: "c", fields: ["test", "id"], unique: true, sparse: false }
+                        { fields: "test" }
+                        { fields: ["test", "id"], unique: true }
+                        { fields: ["test", "id"], unique: true, sparse: false }
                     ]
                 ) {
                 test: String
@@ -53,19 +53,19 @@ describe('createModel', () => {
         expect(model.validate().getErrors(), model.validate().toString()).to.deep.equal([]);
         const testType = model.getRootEntityTypeOrThrow('Test');
 
-        const indexA = testType.indices.find(index => index.id === 'a');
+        const indexA = testType.indices[0];
         expect(indexA).not.to.be.undefined;
         expect(indexA!.fields.map(f => f.path).join(',')).to.equal('test');
         expect(indexA!.unique).to.equal(false);
         expect(indexA!.sparse).to.equal(false);
 
-        const indexB = testType.indices.find(index => index.id === 'b');
+        const indexB = testType.indices[1];
         expect(indexB).not.to.be.undefined;
         expect(indexB!.fields.map(f => f.path).join(',')).to.equal('test,id');
         expect(indexB!.unique).to.equal(true);
         expect(indexB!.sparse).to.equal(true);
 
-        const indexC = testType.indices.find(index => index.id === 'c');
+        const indexC = testType.indices[2];
         expect(indexC).not.to.be.undefined;
         expect(indexC!.fields.map(f => f.path).join(',')).to.equal('test,id');
         expect(indexC!.unique).to.equal(true);

--- a/src/database/arangodb/config.ts
+++ b/src/database/arangodb/config.ts
@@ -69,11 +69,11 @@ export interface ArangoDBConfig {
     readonly createCollectionOptions?: CreateCollectionOptions;
 
     /**
-     * A regular expression that matches index ids that should not be deleted with migrations
+     * A regular expression that matches index names that should not be deleted with migrations
      *
-     * Indices without ID will never be ignored.
+     * Indices without names will never be ignored.
      */
-    readonly ignoredIndexIDsPattern?: RegExp;
+    readonly nonManagedIndexNamesPattern?: RegExp;
 }
 
 export function initDatabase(config: ArangoDBConfig): Database {

--- a/src/meta-schema/meta-schema.ts
+++ b/src/meta-schema/meta-schema.ts
@@ -90,7 +90,8 @@ const typeDefs = gql`
     }
 
     type Index {
-        id: String
+        id: String @deprecated(reason: "has no effect, do not use")
+
         unique: Boolean!
         sparse: Boolean!
         fields: [IndexField!]!

--- a/src/model/config/indices.ts
+++ b/src/model/config/indices.ts
@@ -1,7 +1,8 @@
 import { DirectiveNode, ObjectValueNode, StringValueNode } from 'graphql';
 
 export interface IndexDefinitionConfig {
-    readonly id?: string;
+    readonly name?: string;
+    readonly nameASTNode?: StringValueNode;
     /**
      * A list of dot-separated fields that make up this index
      */

--- a/src/model/create-model.ts
+++ b/src/model/create-model.ts
@@ -640,11 +640,14 @@ function buildIndexDefinitionFromObjectValue(indexDefinitionNode: ObjectValueNod
 }
 
 function mapIndexDefinition(index: ObjectValueNode): IndexDefinitionConfig {
-    const value = valueFromAST(index, indexDefinitionInputObjectType);
+    const { id, name, ...value } = valueFromAST(index, indexDefinitionInputObjectType);
     const fieldsField = index.fields.find(f => f.name.value === 'fields');
     const fieldASTNodes = fieldsField && fieldsField.value.kind === 'ListValue' ? fieldsField.value.values : undefined;
+    const nameASTNode = index.fields.find(f => f.name.value === 'name');
     return {
         ...value,
+        name,
+        nameASTNode,
         fieldASTNodes
     };
 }

--- a/src/schema/graphql-base.ts
+++ b/src/schema/graphql-base.ts
@@ -204,6 +204,7 @@ export const DIRECTIVES: DocumentNode = gql`
     directive @defaultValue(value: JSON!) on FIELD_DEFINITION
 
     input IndexDefinition {
+        "Deprecated, has no effect. Do not use."
         id: String
         fields: [String!]!
         unique: Boolean = false


### PR DESCRIPTION
Added name functionality without thinking about it, not sure if we want to make this configurable at all, so it's not active yet.