### PR TITLE
Optimize create-many operations

### DIFF
--- a/src/authorization/transformers/create-entities.ts
+++ b/src/authorization/transformers/create-entities.ts
@@ -1,0 +1,62 @@
+import { AggregationOperator } from '../../model';
+import {
+    AggregationQueryNode,
+    CreateEntitiesQueryNode,
+    ErrorIfNotTruthyResultValidator,
+    PERMISSION_DENIED_ERROR,
+    PreExecQueryParms,
+    QueryNode,
+    RuntimeErrorQueryNode,
+    TransformListQueryNode,
+    VariableQueryNode,
+    WithPreExecutionQueryNode
+} from '../../query-tree';
+import { AccessOperation, AuthContext } from '../auth-basics';
+import { ConditionExplanationContext, PermissionResult } from '../permission-descriptors';
+import { getPermissionDescriptorOfRootEntityType } from '../permission-descriptors-in-model';
+
+export function transformCreateEntitiesQueryNode(node: CreateEntitiesQueryNode, authContext: AuthContext): QueryNode {
+    const permissionDescriptor = getPermissionDescriptorOfRootEntityType(node.rootEntityType);
+    const access = permissionDescriptor.canAccess(authContext, AccessOperation.CREATE);
+
+    switch (access) {
+        case PermissionResult.GRANTED:
+            return node;
+        case PermissionResult.DENIED:
+            return new RuntimeErrorQueryNode(`Not authorized to create ${node.rootEntityType.name} objects`, {
+                code: PERMISSION_DENIED_ERROR
+            });
+        default:
+            const objectVar = new VariableQueryNode('object');
+            const singleCondition = permissionDescriptor.getAccessCondition(
+                authContext,
+                AccessOperation.CREATE,
+                objectVar
+            );
+            const condition = new AggregationQueryNode(
+                new TransformListQueryNode({
+                    listNode: node.objectsNode,
+                    itemVariable: objectVar,
+                    innerNode: singleCondition
+                }),
+                AggregationOperator.EVERY_TRUE
+            );
+            const explanation = permissionDescriptor.getExplanationForCondition(
+                authContext,
+                AccessOperation.CREATE,
+                ConditionExplanationContext.SET
+            );
+            return new WithPreExecutionQueryNode({
+                resultNode: node,
+                preExecQueries: [
+                    new PreExecQueryParms({
+                        query: condition,
+                        resultValidator: new ErrorIfNotTruthyResultValidator({
+                            errorCode: PERMISSION_DENIED_ERROR,
+                            errorMessage: `Not authorized to ${explanation}`
+                        })
+                    })
+                ]
+            });
+    }
+}

--- a/src/authorization/transformers/index.ts
+++ b/src/authorization/transformers/index.ts
@@ -1,7 +1,21 @@
-import { AffectedFieldInfoQueryNode, CreateEntityQueryNode, DeleteEntitiesQueryNode, EntitiesQueryNode, EntityFromIdQueryNode, FieldPathQueryNode, FieldQueryNode, FollowEdgeQueryNode, QueryNode, TraversalQueryNode, UpdateEntitiesQueryNode } from '../../query-tree';
+import {
+    AffectedFieldInfoQueryNode,
+    CreateEntitiesQueryNode,
+    CreateEntityQueryNode,
+    DeleteEntitiesQueryNode,
+    EntitiesQueryNode,
+    EntityFromIdQueryNode,
+    FieldPathQueryNode,
+    FieldQueryNode,
+    FollowEdgeQueryNode,
+    QueryNode,
+    TraversalQueryNode,
+    UpdateEntitiesQueryNode
+} from '../../query-tree';
 import { FlexSearchQueryNode } from '../../query-tree/flex-search';
 import { AuthContext } from '../auth-basics';
 import { transformAffectedFieldInfoQueryNode } from './affected-field-info';
+import { transformCreateEntitiesQueryNode } from './create-entities';
 import { transformCreateEntityQueryNode } from './create-entity';
 import { transformEntitiesQueryNode, transformEntityFromIdQueryNode, transformFlexSearchQueryNode } from './entities';
 import { transformFieldPathQueryNode, transformFieldQueryNode } from './field';
@@ -13,7 +27,7 @@ type TransformFunction<T extends QueryNode> = (node: T, authContext: AuthContext
 
 const map = new Map<Function, TransformFunction<any>>();
 
-function addTransformer<T extends QueryNode>(clazz: { new(...a: any[]): T }, fn: TransformFunction<T>) {
+function addTransformer<T extends QueryNode>(clazz: { new (...a: any[]): T }, fn: TransformFunction<T>) {
     map.set(clazz, fn);
 }
 
@@ -23,6 +37,7 @@ addTransformer(EntitiesQueryNode, transformEntitiesQueryNode);
 addTransformer(FollowEdgeQueryNode, transformFollowEdgeQueryNode);
 addTransformer(TraversalQueryNode, transformTraversalQueryNode);
 addTransformer(CreateEntityQueryNode, transformCreateEntityQueryNode);
+addTransformer(CreateEntitiesQueryNode, transformCreateEntitiesQueryNode);
 addTransformer(UpdateEntitiesQueryNode, transformUpdateEntitiesQueryNode);
 addTransformer(DeleteEntitiesQueryNode, transformDeleteEntitiesQueryNode);
 addTransformer(AffectedFieldInfoQueryNode, transformAffectedFieldInfoQueryNode);

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -15,6 +15,7 @@ import {
     ConstIntQueryNode,
     CountQueryNode,
     CreateBillingEntityQueryNode,
+    CreateEntitiesQueryNode,
     CreateEntityQueryNode,
     DeleteEntitiesQueryNode,
     DeleteEntitiesResultValue,
@@ -1463,6 +1464,15 @@ register(CreateEntityQueryNode, (node, context) => {
             AccessType.WRITE,
             context
         )}`,
+        aql`RETURN NEW._key`
+    );
+});
+
+register(CreateEntitiesQueryNode, (node, context) => {
+    const entityVar = aql.variable('entity');
+    return aqlExt.parenthesizeList(
+        aql`FOR ${entityVar} IN ${processNode(node.objectsNode, context)}`,
+        aql`INSERT ${entityVar} IN ${getCollectionForType(node.rootEntityType, AccessType.WRITE, context)}`,
         aql`RETURN NEW._key`
     );
 });

--- a/src/database/inmemory/js-generator.ts
+++ b/src/database/inmemory/js-generator.ts
@@ -15,6 +15,7 @@ import {
     ConstIntQueryNode,
     CountQueryNode,
     CreateBillingEntityQueryNode,
+    CreateEntitiesQueryNode,
     CreateEntityQueryNode,
     DeleteEntitiesQueryNode,
     DynamicPropertyAccessQueryNode,
@@ -830,6 +831,16 @@ register(CreateEntityQueryNode, (node, context) => {
         js`${js.collection(getCollectionNameForRootEntity(node.rootEntityType))}.push(${objVar});`,
         js`return ${idVar};`
     );
+});
+
+register(CreateEntitiesQueryNode, (node, context) => {
+    const objectVar = new VariableQueryNode('object');
+    const transformedNode = new TransformListQueryNode({
+        listNode: node.objectsNode,
+        itemVariable: objectVar,
+        innerNode: new CreateEntityQueryNode(node.rootEntityType, objectVar, node.affectedFields)
+    });
+    return processNode(transformedNode, context);
 });
 
 register(UpdateEntitiesQueryNode, (node, context) => {

--- a/src/query-tree/mutations.ts
+++ b/src/query-tree/mutations.ts
@@ -26,6 +26,27 @@ export class CreateEntityQueryNode extends QueryNode {
 }
 
 /**
+ * A node that creates multiple new entities of the same type and evaluates to the list of these new entity objects
+ */
+export class CreateEntitiesQueryNode extends QueryNode {
+    constructor(
+        public readonly rootEntityType: RootEntityType,
+        public readonly objectsNode: QueryNode,
+        public readonly affectedFields: ReadonlyArray<AffectedFieldInfoQueryNode>
+    ) {
+        super();
+    }
+
+    describe() {
+        return `create ${
+            this.rootEntityType.name
+        } entities with values ${this.objectsNode.describe()} (affects fields ${this.affectedFields
+            .map(f => f.describe())
+            .join(', ')})`;
+    }
+}
+
+/**
  * A node that indicates that a field of a node is set, without being evaluated
  */
 export class AffectedFieldInfoQueryNode extends QueryNode {

--- a/src/schema-generation/mutation-type-generator.ts
+++ b/src/schema-generation/mutation-type-generator.ts
@@ -170,16 +170,15 @@ export class MutationTypeGenerator {
         inputType: CreateRootEntityInputType,
         context: FieldContext
     ): QueryNode {
-        const idNodes: VariableQueryNode[] = [];
-        const statements: PreExecQueryParms[] = [];
-        for (const input of inputs) {
-            const newEntityIdVarNode = new VariableQueryNode('newEntityId');
-            const createStatements = inputType.getCreateStatements(input, newEntityIdVarNode, context);
-            statements.push(...createStatements);
-            idNodes.push(newEntityIdVarNode);
-        }
+        const idsVar = new VariableQueryNode('newEntityIds');
+        const statements = inputType.getMultiCreateStatements(inputs, idsVar, context);
 
-        const resultNode = new ListQueryNode(idNodes.map(idNode => new EntityFromIdQueryNode(rootEntityType, idNode)));
+        const idVar = new VariableQueryNode('id');
+        const resultNode = new TransformListQueryNode({
+            listNode: idsVar,
+            itemVariable: idVar,
+            innerNode: new EntityFromIdQueryNode(rootEntityType, idVar)
+        });
 
         return new WithPreExecutionQueryNode({
             resultNode,


### PR DESCRIPTION
Now, creating many entities only executes one AQL query and not one AQL query per entity, as long as no additional edges or billing are involved.