### PR TITLE
Pass implicitly accessed collections to ArangoDB for cluster compatibility

### DIFF
--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -285,18 +285,14 @@ class QueryContext {
     }
 
     /**
-     * Gets the names of all collections that are read by this query, but are not explicitly
-     * referenced within it (to be used with the WITH statement)
+     * Gets the names of all collections that are read by this query, but are not necessarily
+     * referenced explicitly within it (to be used with the WITH statement)
      */
     getImplicitlyReadAccessedCollections(): ReadonlyArray<string> {
-        const set = new Set(this.implicitlyReadAccessedCollections);
-        for (const collection of this.explicitlyReadAccessedCollections) {
-            set.delete(collection);
-        }
-        for (const collection of this.writeAccessedCollections) {
-            set.delete(collection);
-        }
-        return Array.from(set);
+        return Array.from(this.implicitlyReadAccessedCollections);
+        // note: we could remove the explicitly accessed collections here, but this is currently a
+        // bit hard because the collection sets are shared across the whole transaction and not
+        // scoped to a single query
     }
 }
 

--- a/src/database/arangodb/aql.ts
+++ b/src/database/arangodb/aql.ts
@@ -428,8 +428,8 @@ export class AQLCompoundQuery extends AQLFragment {
         public readonly aqlQuery: AQLFragment,
         public readonly resultVar: AQLQueryResultVariable | undefined,
         public readonly resultValidator: QueryResultValidator | undefined,
-        public readonly readAccessedCollections: string[],
-        public readonly writeAccessedCollections: string[],
+        public readonly readAccessedCollections: ReadonlyArray<string>,
+        public readonly writeAccessedCollections: ReadonlyArray<string>,
     ) {
         super();
     }

--- a/src/database/arangodb/arangodb-adapter.ts
+++ b/src/database/arangodb/arangodb-adapter.ts
@@ -652,8 +652,8 @@ export class ArangoDBAdapter implements DatabaseAdapter {
         try {
             transactionResult = await this.db.executeTransaction(
                 {
-                    read: aqlQuery.readAccessedCollections,
-                    write: aqlQuery.writeAccessedCollections,
+                    read: aqlQuery.readAccessedCollections.slice(),
+                    write: aqlQuery.writeAccessedCollections.slice(),
                 },
                 this.arangoExecutionFunction,
                 {


### PR DESCRIPTION
This ensures that the AQL generated by cruddl is compatible with cluster deployments.