### PR TITLE
Fix infinite recursion when generating flex search expression query

### DIFF
--- a/src/schema-generation/flex-search-generator.ts
+++ b/src/schema-generation/flex-search-generator.ts
@@ -264,6 +264,7 @@ export class FlexSearchGenerator {
         function getQueryNodeFromField(field: Field, path: Field[] = []): QueryNode {
             if (field.type.isObjectType) {
                 return field.type.fields
+                    .filter((f) => f.isFlexSearchIndexed || f.isFlexSearchFulltextIndexed)
                     .map((value) => getQueryNodeFromField(value, path.concat(field)))
                     .reduce(or, ConstBoolQueryNode.FALSE);
             }


### PR DESCRIPTION
The whole logic as to which fields to include in the search expression is buggy and inconsistent, but this is at least a simple non-breaking fix.