### PR TITLE
fix: populate extensions.code of runtime errors

### DIFF
--- a/spec/regression/access-groups/tests/flex-search.result.json
+++ b/spec/regression/access-groups/tests/flex-search.result.json
@@ -9,7 +9,12 @@
             "column": 5
           }
         ],
-        "path": ["flexSearchFiles"]
+        "path": [
+          "flexSearchFiles"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/logistics/tests/field-permission-denied.result.json
@@ -19,7 +19,10 @@
         "path": [
           "Delivery",
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects (in Delivery.forwarder)",
@@ -32,7 +35,10 @@
         "path": [
           "Delivery",
           "forwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -46,7 +52,10 @@
           "allDeliveries",
           0,
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -60,7 +69,10 @@
           "HandlingUnit",
           "delivery",
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Country.totalInvestment",
@@ -73,7 +85,10 @@
         "path": [
           "Country",
           "totalInvestment"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -113,7 +128,10 @@
         "path": [
           "_allForwardersMeta",
           "count"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects",
@@ -125,7 +143,10 @@
         ],
         "path": [
           "allForwarders"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -147,7 +168,10 @@
         ],
         "path": [
           "direct"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read SecretKey.key",
@@ -159,7 +183,10 @@
         ],
         "path": [
           "simple"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -171,7 +198,10 @@
         ],
         "path": [
           "startsWith"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -183,7 +213,10 @@
         ],
         "path": [
           "throughRelation"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects (in Delivery.forwarder)",
@@ -195,7 +228,10 @@
         ],
         "path": [
           "toUnaccessibleEntity"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -218,7 +254,10 @@
         ],
         "path": [
           "direct"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -230,7 +269,10 @@
         ],
         "path": [
           "throughRelation"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -250,7 +292,10 @@
         ],
         "path": [
           "createDelivery"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": null
@@ -267,7 +312,10 @@
         ],
         "path": [
           "updateDelivery"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to update Forwarder objects, Not authorized to read Forwarder objects",
@@ -279,7 +327,10 @@
         ],
         "path": [
           "updateForwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Skipped because other mutations reported errors",
@@ -291,7 +342,10 @@
         ],
         "path": [
           "update2"
-        ]
+        ],
+        "extensions": {
+          "code": "ATOMICITY_SKIP"
+        }
       }
     ],
     "data": {
@@ -312,7 +366,10 @@
         ],
         "path": [
           "deleteForwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/flex-search-in-memory.result.json
+++ b/spec/regression/logistics/tests/flex-search-in-memory.result.json
@@ -220,7 +220,10 @@
         ],
         "path": [
           "flexSearchDeliveries"
-        ]
+        ],
+        "extensions": {
+          "code": "FLEX_SEARCH_TOO_MANY_OBJECTS"
+        }
       }
     ],
     "data": {
@@ -239,7 +242,10 @@
         ],
         "path": [
           "flexSearchDeliveries"
-        ]
+        ],
+        "extensions": {
+          "code": "FLEX_SEARCH_TOO_MANY_OBJECTS"
+        }
       }
     ],
     "data": {
@@ -258,7 +264,10 @@
         ],
         "path": [
           "_flexSearchDeliveriesMeta"
-        ]
+        ],
+        "extensions": {
+          "code": "FLEX_SEARCH_TOO_MANY_OBJECTS"
+        }
       }
     ],
     "data": null
@@ -275,7 +284,10 @@
         ],
         "path": [
           "flexSearchDeliveries"
-        ]
+        ],
+        "extensions": {
+          "code": "FLEX_SEARCH_TOO_MANY_OBJECTS"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/flex-search-primary-sort.result.json
+++ b/spec/regression/logistics/tests/flex-search-primary-sort.result.json
@@ -9,7 +9,12 @@
             "column": 5
           }
         ],
-        "path": ["flexSearchHandlingUnits"]
+        "path": [
+          "flexSearchHandlingUnits"
+        ],
+        "extensions": {
+          "code": "FLEX_SEARCH_TOO_MANY_OBJECTS"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/permissions-creator.result.json
+++ b/spec/regression/logistics/tests/permissions-creator.result.json
@@ -16,7 +16,12 @@
             "column": 5
           }
         ],
-        "path": ["updateDelivery"]
+        "path": [
+          "updateDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -33,7 +38,12 @@
             "column": 5
           }
         ],
-        "path": ["deleteDelivery"]
+        "path": [
+          "deleteDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/permissions-deleter.result.json
+++ b/spec/regression/logistics/tests/permissions-deleter.result.json
@@ -9,7 +9,12 @@
             "column": 5
           }
         ],
-        "path": ["createDelivery"]
+        "path": [
+          "createDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": null
@@ -24,7 +29,12 @@
             "column": 5
           }
         ],
-        "path": ["updateDelivery"]
+        "path": [
+          "updateDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/logistics/tests/permissions-updater.result.json
+++ b/spec/regression/logistics/tests/permissions-updater.result.json
@@ -9,7 +9,12 @@
             "column": 5
           }
         ],
-        "path": ["createDelivery"]
+        "path": [
+          "createDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": null
@@ -31,7 +36,12 @@
             "column": 5
           }
         ],
-        "path": ["deleteDelivery"]
+        "path": [
+          "deleteDelivery"
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
+++ b/spec/regression/namespaced_logistics/tests/field-permission-denied.result.json
@@ -25,7 +25,10 @@
           "delivery",
           "Delivery",
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects (in Delivery.forwarder)",
@@ -40,7 +43,10 @@
           "delivery",
           "Delivery",
           "forwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -56,7 +62,10 @@
           "allDeliveries",
           0,
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -72,7 +81,10 @@
           "HandlingUnit",
           "delivery",
           "totalValue"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Country.totalInvestment",
@@ -86,7 +98,10 @@
           "foundation",
           "Country",
           "totalInvestment"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -132,7 +147,10 @@
         "path": [
           "logistics",
           "allForwarders"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects",
@@ -146,7 +164,10 @@
           "logistics",
           "_allForwardersMeta",
           "count"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -172,7 +193,10 @@
           "logistics",
           "delivery",
           "direct"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -186,7 +210,10 @@
           "logistics",
           "delivery",
           "startsWith"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -200,7 +227,10 @@
           "logistics",
           "delivery",
           "throughRelation"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Forwarder objects (in Delivery.forwarder)",
@@ -214,7 +244,10 @@
           "logistics",
           "delivery",
           "toUnaccessibleEntity"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read SecretKey.key",
@@ -227,7 +260,10 @@
         "path": [
           "simple",
           "SecretKey"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -258,7 +294,10 @@
           "logistics",
           "delivery",
           "direct"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to read Delivery.totalValue",
@@ -272,7 +311,10 @@
           "logistics",
           "delivery",
           "throughRelation"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -298,7 +340,10 @@
           "logistics",
           "delivery",
           "createDelivery"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Not authorized to create Forwarder objects, Not authorized to read Forwarder objects",
@@ -311,7 +356,10 @@
         "path": [
           "logistics",
           "createForwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -332,7 +380,10 @@
           "logistics",
           "delivery",
           "updateDelivery"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       },
       {
         "message": "Skipped because other mutations reported errors",
@@ -346,7 +397,10 @@
           "logistics",
           "delivery",
           "update2"
-        ]
+        ],
+        "extensions": {
+          "code": "ATOMICITY_SKIP"
+        }
       },
       {
         "message": "Not authorized to update Forwarder objects, Not authorized to read Forwarder objects",
@@ -359,7 +413,10 @@
         "path": [
           "logistics",
           "updateForwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {
@@ -385,7 +442,10 @@
         "path": [
           "logistics",
           "deleteForwarder"
-        ]
+        ],
+        "extensions": {
+          "code": "PERMISSION_DENIED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/papers/tests/invalid-cursors.result.json
+++ b/spec/regression/papers/tests/invalid-cursors.result.json
@@ -1,56 +1,71 @@
 {
-  "invalidJSON": {
-    "data": {
-      "allPapers": null
-    },
+  "missingProperty": {
     "errors": [
       {
+        "message": "Invalid cursor supplied to \"after\": Property \"title\" missing. Make sure this cursor has been obtained with the same orderBy clause.",
         "locations": [
           {
-            "column": 5,
-            "line": 12
+            "line": 6,
+            "column": 5
           }
         ],
-        "message": "Invalid cursor \"this-is-not-json\" supplied to \"after\": Unexpected token h in JSON at position 1",
-        "path": ["allPapers"]
+        "path": [
+          "allPapers"
+        ],
+        "extensions": {
+          "code": "INVALID_CURSOR"
+        }
       }
-    ]
-  },
-  "missingProperty": {
+    ],
     "data": {
       "Paper": {
         "title": "Object-oriented modeling and design"
       },
       "allPapers": null
-    },
+    }
+  },
+  "invalidJSON": {
     "errors": [
       {
+        "message": "Invalid cursor \"this-is-not-json\" supplied to \"after\": Unexpected token h in JSON at position 1",
         "locations": [
           {
-            "column": 5,
-            "line": 6
+            "line": 12,
+            "column": 5
           }
         ],
-        "message": "Invalid cursor supplied to \"after\": Property \"title\" missing. Make sure this cursor has been obtained with the same orderBy clause.",
-        "path": ["allPapers"]
+        "path": [
+          "allPapers"
+        ],
+        "extensions": {
+          "code": "INVALID_CURSOR"
+        }
       }
-    ]
-  },
-  "nonObjectJSON": {
+    ],
     "data": {
       "allPapers": null
-    },
+    }
+  },
+  "nonObjectJSON": {
     "errors": [
       {
+        "message": "The JSON value provided as \"after\" argument is not an object",
         "locations": [
           {
-            "column": 5,
-            "line": 18
+            "line": 18,
+            "column": 5
           }
         ],
-        "message": "The JSON value provided as \"after\" argument is not an object",
-        "path": ["allPapers"]
+        "path": [
+          "allPapers"
+        ],
+        "extensions": {
+          "code": "INVALID_CURSOR"
+        }
       }
-    ]
+    ],
+    "data": {
+      "allPapers": null
+    }
   }
 }

--- a/spec/regression/root-fields/tests/root-and-parent-with-collect.result.json
+++ b/spec/regression/root-fields/tests/root-and-parent-with-collect.result.json
@@ -16,7 +16,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 0, "grandchildren", 0, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          0,
+          "grandchildren",
+          0,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -26,7 +37,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "grandchildren", 0, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "grandchildren",
+          0,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -36,7 +58,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "grandchildren", 1, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "grandchildren",
+          1,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -46,7 +79,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "grandchildren", 2, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "grandchildren",
+          2,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -56,7 +100,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "grandchildren", 3, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "grandchildren",
+          3,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -66,7 +121,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "extensionGrandchildren", 0, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "extensionGrandchildren",
+          0,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -76,7 +142,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "extensionGrandchildren", 1, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "extensionGrandchildren",
+          1,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -86,7 +163,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "extensionGrandchildren", 2, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "extensionGrandchildren",
+          2,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -96,7 +184,18 @@
             "column": 17
           }
         ],
-        "path": ["allRoot2s", 0, "roots", 1, "extensionGrandchildren", 3, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "roots",
+          1,
+          "extensionGrandchildren",
+          3,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -106,7 +205,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootGrandchildren", 0, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootGrandchildren",
+          0,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -116,7 +224,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootGrandchildren", 1, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootGrandchildren",
+          1,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -126,7 +243,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootGrandchildren", 2, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootGrandchildren",
+          2,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -136,7 +262,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootGrandchildren", 3, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootGrandchildren",
+          3,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -146,7 +281,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootGrandchildren", 4, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootGrandchildren",
+          4,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -156,7 +300,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootExtensionGrandchildren", 0, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootExtensionGrandchildren",
+          0,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -166,7 +319,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootExtensionGrandchildren", 1, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootExtensionGrandchildren",
+          1,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -176,7 +338,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootExtensionGrandchildren", 2, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootExtensionGrandchildren",
+          2,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       },
       {
         "message": "Parent entity is not available here",
@@ -186,7 +357,16 @@
             "column": 13
           }
         ],
-        "path": ["allRoot2s", 0, "rootExtensionGrandchildren", 3, "parent"]
+        "path": [
+          "allRoot2s",
+          0,
+          "rootExtensionGrandchildren",
+          3,
+          "parent"
+        ],
+        "extensions": {
+          "code": "NOT_SUPPORTED"
+        }
       }
     ],
     "data": {

--- a/spec/regression/root-fields/tests/root-and-parent-with-intra-root-entity-collect.result.json
+++ b/spec/regression/root-fields/tests/root-and-parent-with-intra-root-entity-collect.result.json
@@ -12,7 +12,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 0, "grandchildren", 0, "parent"]
+      "path": [
+        "allRoots",
+        0,
+        "grandchildren",
+        0,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -26,7 +35,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "grandchildren", 0, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "grandchildren",
+        0,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -40,7 +58,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "grandchildren", 1, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "grandchildren",
+        1,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -54,7 +81,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "grandchildren", 2, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "grandchildren",
+        2,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -68,7 +104,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "grandchildren", 3, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "grandchildren",
+        3,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -82,7 +127,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "extensionGrandchildren", 0, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "extensionGrandchildren",
+        0,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -96,7 +150,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "extensionGrandchildren", 1, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "extensionGrandchildren",
+        1,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -110,7 +173,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "extensionGrandchildren", 2, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "extensionGrandchildren",
+        2,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     },
     {
       "message": "Parent entity is not available here",
@@ -124,7 +196,16 @@
           "column": 13
         }
       ],
-      "path": ["allRoots", 1, "extensionGrandchildren", 3, "parent"]
+      "path": [
+        "allRoots",
+        1,
+        "extensionGrandchildren",
+        3,
+        "parent"
+      ],
+      "extensions": {
+        "code": "NOT_SUPPORTED"
+      }
     }
   ],
   "data": {

--- a/src/query-tree/errors.ts
+++ b/src/query-tree/errors.ts
@@ -72,10 +72,23 @@ export function extractRuntimeError(value: RuntimeErrorValue): RuntimeError {
 export class RuntimeError extends Error {
     readonly code: string | undefined;
 
+    /**
+     * Extensions to be used when formatting this as a graphql error
+     */
+    readonly extensions: Record<string, unknown> | undefined;
+
     constructor(message: string, args: { readonly code?: string } = {}) {
         super(message);
         this.name = this.constructor.name;
         this.code = args.code;
+
+        if (args.code) {
+            // this is used by the GraphQLError constructor to populate the extensions
+            // (otherwise, the code would not be reported to the client)
+            this.extensions = {
+                code: args.code,
+            };
+        }
     }
 }
 


### PR DESCRIPTION
Without this fix, runtime errors (e.g. authorization problems) would not properly set the error code in a formatted GraphQL error.

Not sure why this worked before. It definitely did not work in the regression tests.