### PR TITLE
fix: warn about calcMutations within value objects

### DIFF
--- a/spec/model/implementation/field.spec.ts
+++ b/spec/model/implementation/field.spec.ts
@@ -925,5 +925,21 @@ describe('Field', () => {
 
             expectSingleErrorToInclude(field, `Calc mutations are not supported on list fields.`);
         });
+
+        it('warns about @calcMutations within a value object', () => {
+            const field = new Field(
+                {
+                    name: 'amount',
+                    typeName: 'Int',
+                    calcMutationOperators: [CalcMutationsOperator.ADD],
+                },
+                addressType,
+            );
+
+            expectSingleWarningToInclude(
+                field,
+                `Calc mutations do not work within value objects because value objects cannot be updated. This will be an error in a future release.`,
+            );
+        });
     });
 });

--- a/src/model/implementation/field.ts
+++ b/src/model/implementation/field.ts
@@ -1255,6 +1255,15 @@ export class Field implements ModelComponent {
                 );
             }
         }
+
+        if (this.declaringType.isValueObjectType) {
+            context.addMessage(
+                ValidationMessage.warn(
+                    `Calc mutations do not work within value objects because value objects cannot be updated. This will be an error in a future release.`,
+                    this.astNode,
+                ),
+            );
+        }
     }
 
     private validateParentField(context: ValidationContext) {


### PR DESCRIPTION
This directive does not work and does not generate any fields when used within a value object.

For easier transition, make this a warning first.