### PR TITLE
feat: add cruddlVersion to meta schema and mention it in the description

### DIFF
--- a/spec/meta-schema/meta-schema.spec.ts
+++ b/spec/meta-schema/meta-schema.spec.ts
@@ -162,6 +162,20 @@ describe('Meta schema API', () => {
         }
     `;
 
+    const cruddlVersionQuery = gql`
+        {
+            cruddlVersion
+        }
+    `;
+
+    const cruddlVersionIntrospectionQuery = gql`
+        {
+            __type(name: "Query") {
+                description
+            }
+        }
+    `;
+
     const model = new Model({
         types: [
             {
@@ -942,6 +956,27 @@ describe('Meta schema API', () => {
                 { name: 'destinationCountry', permissions: { canRead: false, canWrite: false } },
             ],
         });
+    });
+
+    it('can query read the cruddl version', async () => {
+        const expectedVersion = require('../../package.json').version;
+        const result = await execute(cruddlVersionQuery);
+        const actualVersion = result!.cruddlVersion as string;
+
+        expect(typeof actualVersion).to.equal('string');
+        expect(actualVersion.length).to.be.greaterThan(0);
+        expect(actualVersion).to.deep.equal(expectedVersion);
+    });
+
+    it('can query read the cruddl version from meta description', async () => {
+        const expectedVersion = require('../../package.json').version;
+        const result = (await execute(cruddlVersionIntrospectionQuery)) as any;
+        const description = result.__type.description as string;
+        const actualVersion = description.match(/cruddlVersion: "(.*)"/)![1];
+
+        expect(typeof actualVersion).to.equal('string');
+        expect(actualVersion.length).to.be.greaterThan(0);
+        expect(actualVersion).to.deep.equal(expectedVersion);
     });
 
     after(function () {

--- a/src/meta-schema/meta-schema.ts
+++ b/src/meta-schema/meta-schema.ts
@@ -19,6 +19,8 @@ const resolutionOrderDescription = JSON.stringify(
     'The order in which languages and other localization providers are queried for a localization. You can specify languages as defined in the schema as well as the following special identifiers:\n\n- `_LOCALE`: The language defined by the GraphQL request (might be a list of languages, e.g. ["de_DE", "de", "en"])\n- `_GENERIC`: is auto-generated localization from field and type names (e. G. `orderDate` => `Order date`)\n\nThe default `resolutionOrder` is `["_LOCALE", "_GENERIC"]` (if not specified).',
 );
 
+const cruddlVersion = require('../../package.json').version;
+
 const typeDefs = gql`
     enum TypeKind {
         ROOT_ENTITY, CHILD_ENTITY, ENTITY_EXTENSION, VALUE_OBJECT, ENUM, SCALAR
@@ -341,6 +343,10 @@ const typeDefs = gql`
     This differs from the GraphQL introspection types like \`__Schema\` in that it excludes auto-generated types and
     fields like input types or the \`count\` field for lists, and it provides additional type information like type
     kinds and relations.
+    
+    You can parse the following part of this comment for feature detection (it won't change the format):
+    
+    cruddlVersion: "${cruddlVersion}"
     """
     type Query {
         "A list of all user-defined and system-provided types"
@@ -420,6 +426,14 @@ const typeDefs = gql`
 
         "The billingEntityTypes that define the billing configuration."
         billingEntityTypes: [BillingEntityType!]!
+
+        """
+        The version of cruddl, the library serving the schema
+    
+        Equals the npm package version and follows semantic versioning. You can use this to test for
+        support for schema features.
+        """
+        cruddlVersion: String
     }
 
     type Subscription {
@@ -511,6 +525,14 @@ const typeDefs = gql`
 
         "The billingEntityTypes that define the billing configuration."
         billingEntityTypes: [BillingEntityType!]!
+    
+        """
+        The version of cruddl, the library serving the schema
+        
+        Equals the npm package version and follows semantic versioning. You can use this to test for
+        support for schema features.
+        """
+        cruddlVersion: String
     }
 `;
 
@@ -540,6 +562,7 @@ export function getMetaSchema(project: Project): GraphQLSchema {
             rootNamespace: () => model.rootNamespace,
             namespace: (_, { path }) => model.getNamespaceByPath(path),
             billingEntityTypes: () => model.billingEntityTypes,
+            cruddlVersion: () => cruddlVersion,
         },
         // to be used within the subscription type, so we don't use the "Query" type there in case we want to add something there
         Schema: {
@@ -561,6 +584,7 @@ export function getMetaSchema(project: Project): GraphQLSchema {
             rootNamespace: () => model.rootNamespace,
             namespace: (_, { path }) => model.getNamespaceByPath(path),
             billingEntityTypes: () => model.billingEntityTypes,
+            cruddlVersion: () => cruddlVersion,
         },
         Subscription: {
             schema: {


### PR DESCRIPTION
Consumers that know they are talking to cruddl but do not know which version cruddl runs in might need to decide which features they can use. This can be useful to enable certain filters for example.

For now, they should request the description of the Query type of the meta schema and parse the line

    cruddlVersion: "..."

This does not generate an error on older cruddl version (but obviously does not find the vesion).

When the client knows the running cruddl version is recent enough, they can also request the new cruddlVersion field in the meta schema, but this will fail if cruddl is not new enough to have this field.