### PR TITLE
perf: improve performance of bulk child entity updates and avoid hitting the AQL limit of 500 nesting limit doing it

### DIFF
--- a/core-exports.ts
+++ b/core-exports.ts
@@ -13,6 +13,8 @@ export {
     ExecutionOptions,
     MutationMode,
     ExecutionOptionsCallbackArgs,
+    Clock,
+    IDGenerator,
 } from './src/execution/execution-options';
 export { ExecutionResult } from './src/execution/execution-result';
 export {

--- a/spec/regression/logistics/default-context.json
+++ b/spec/regression/logistics/default-context.json
@@ -1,3 +1,4 @@
 {
-  "authRoles": ["allusers"]
+  "authRoles": ["allusers"],
+  "childEntityUpdatesViaDictStrategyThreshold": 2
 }

--- a/spec/regression/logistics/tests/update-child-entities-dict.context.json
+++ b/spec/regression/logistics/tests/update-child-entities-dict.context.json
@@ -1,0 +1,4 @@
+{
+  "childEntityUpdatesViaDictStrategyThreshold": 1,
+  "authRoles": ["allusers"]
+}

--- a/spec/regression/logistics/tests/update-child-entities-dict.graphql
+++ b/spec/regression/logistics/tests/update-child-entities-dict.graphql
@@ -1,5 +1,5 @@
-# in the .context.json, childEntityUpdatesViaDictStrategyThreshold is set to 100
-# so we will never use the dict strategy to update child entities
+# in the .context.json, childEntityUpdatesViaDictStrategyThreshold is set to 1
+# so we will always use the dict strategy to update child entities
 
 mutation updateOne {
     updateDelivery(

--- a/spec/regression/logistics/tests/update-child-entities-dict.result.json
+++ b/spec/regression/logistics/tests/update-child-entities-dict.result.json
@@ -1,0 +1,342 @@
+{
+  "updateOne": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          }
+        ]
+      }
+    }
+  },
+  "afterUpdateOne": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          }
+        ]
+      }
+    }
+  },
+  "addSome": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "added03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "added05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "added07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "added08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "added09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "updateMultiple": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "updated07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "afterUpdateMultiple": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "updated07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "addUpdateAndDelete": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "finalUpdated04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          },
+          {
+            "id": "id_test_0011",
+            "itemNumber": "finalNew1"
+          },
+          {
+            "id": "id_test_0012",
+            "itemNumber": "finalUpdated02"
+          }
+        ]
+      }
+    }
+  },
+  "end": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "finalUpdated04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          },
+          {
+            "id": "id_test_0011",
+            "itemNumber": "finalNew1"
+          },
+          {
+            "id": "id_test_0012",
+            "itemNumber": "finalUpdated02"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/regression/logistics/tests/update-child-entities.context.json
+++ b/spec/regression/logistics/tests/update-child-entities.context.json
@@ -1,0 +1,4 @@
+{
+  "childEntityUpdatesViaDictStrategyThreshold": 100,
+  "authRoles": ["allusers"]
+}

--- a/spec/regression/logistics/tests/update-child-entities.graphql
+++ b/spec/regression/logistics/tests/update-child-entities.graphql
@@ -1,0 +1,117 @@
+mutation updateOne {
+    updateDelivery(
+        input: {
+            id: "@{ids/Delivery/1}"
+            updateItems: [{ id: "id_init_0000", itemNumber: "updated1" }]
+        }
+    ) {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+# to verify it is updated in the db
+query afterUpdateOne {
+    Delivery(id: "@{ids/Delivery/1}") {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+mutation addSome {
+    updateDelivery(
+        input: {
+            id: "@{ids/Delivery/1}"
+            addItems: [
+                { itemNumber: "added00" }
+                { itemNumber: "added01" }
+                { itemNumber: "added02" }
+                { itemNumber: "added03" }
+                { itemNumber: "added04" }
+                { itemNumber: "added05" }
+                { itemNumber: "added06" }
+                { itemNumber: "added07" }
+                { itemNumber: "added08" }
+                { itemNumber: "added09" }
+                { itemNumber: "added10" }
+            ]
+        }
+    ) {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+mutation updateMultiple {
+    updateDelivery(
+        input: {
+            id: "@{ids/Delivery/1}"
+            updateItems: [
+                { id: "id_test_0003", itemNumber: "updated03" }
+                { id: "id_test_0005", itemNumber: "updated05" }
+                { id: "id_test_0007", itemNumber: "updated07" }
+                { id: "id_test_0008", itemNumber: "updated08" }
+                { id: "id_test_0009", itemNumber: "updated09" }
+            ]
+        }
+    ) {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+# to verify it is updated in the db
+query afterUpdateMultiple {
+    Delivery(id: "@{ids/Delivery/1}") {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+mutation addUpdateAndDelete {
+    updateDelivery(
+        input: {
+            id: "@{ids/Delivery/1}"
+            addItems: [
+                { itemNumber: "finalNew1" }
+                { itemNumber: "finalNew2" }
+                { itemNumber: "finalNew3" }
+            ]
+            updateItems: [
+                { id: "id_test_0004", itemNumber: "finalUpdated04" }
+                # this is finalNew2
+                { id: "id_test_0012", itemNumber: "finalUpdated02" }
+            ]
+            removeItems: [
+                "id_test_0007"
+                # this is finalNew3
+                "id_test_0013"
+            ]
+        }
+    ) {
+        items {
+            id
+            itemNumber
+        }
+    }
+}
+
+# to verify it is updated in the db
+query end {
+    Delivery(id: "@{ids/Delivery/1}") {
+        items {
+            id
+            itemNumber
+        }
+    }
+}

--- a/spec/regression/logistics/tests/update-child-entities.result.json
+++ b/spec/regression/logistics/tests/update-child-entities.result.json
@@ -1,0 +1,342 @@
+{
+  "updateOne": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          }
+        ]
+      }
+    }
+  },
+  "afterUpdateOne": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          }
+        ]
+      }
+    }
+  },
+  "addSome": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "added03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "added05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "added07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "added08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "added09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "updateMultiple": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "updated07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "afterUpdateMultiple": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "added04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0007",
+            "itemNumber": "updated07"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          }
+        ]
+      }
+    }
+  },
+  "addUpdateAndDelete": {
+    "data": {
+      "updateDelivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "finalUpdated04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          },
+          {
+            "id": "id_test_0011",
+            "itemNumber": "finalNew1"
+          },
+          {
+            "id": "id_test_0012",
+            "itemNumber": "finalUpdated02"
+          }
+        ]
+      }
+    }
+  },
+  "end": {
+    "data": {
+      "Delivery": {
+        "items": [
+          {
+            "id": "id_init_0000",
+            "itemNumber": "updated1"
+          },
+          {
+            "id": "id_init_0001",
+            "itemNumber": "1002"
+          },
+          {
+            "id": "id_test_0000",
+            "itemNumber": "added00"
+          },
+          {
+            "id": "id_test_0001",
+            "itemNumber": "added01"
+          },
+          {
+            "id": "id_test_0002",
+            "itemNumber": "added02"
+          },
+          {
+            "id": "id_test_0003",
+            "itemNumber": "updated03"
+          },
+          {
+            "id": "id_test_0004",
+            "itemNumber": "finalUpdated04"
+          },
+          {
+            "id": "id_test_0005",
+            "itemNumber": "updated05"
+          },
+          {
+            "id": "id_test_0006",
+            "itemNumber": "added06"
+          },
+          {
+            "id": "id_test_0008",
+            "itemNumber": "updated08"
+          },
+          {
+            "id": "id_test_0009",
+            "itemNumber": "updated09"
+          },
+          {
+            "id": "id_test_0010",
+            "itemNumber": "added10"
+          },
+          {
+            "id": "id_test_0011",
+            "itemNumber": "finalNew1"
+          },
+          {
+            "id": "id_test_0012",
+            "itemNumber": "finalUpdated02"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/spec/regression/regression-suite.ts
+++ b/spec/regression/regression-suite.ts
@@ -74,6 +74,8 @@ export class RegressionSuite {
                 authContext: { authRoles: context.authRoles, claims: context.claims },
                 flexSearchMaxFilterableAndSortableAmount:
                     context.flexSearchMaxFilterableAndSortableAmount,
+                childEntityUpdatesViaDictStrategyThreshold:
+                    context.childEntityUpdatesViaDictStrategyThreshold,
                 idGenerator: this.idGenerator,
             }),
             modelOptions: {

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -87,7 +87,7 @@ import {
     getCollectionNameForRootEntity,
 } from './arango-basics';
 import { getFlexSearchViewNameForRootEntity } from './schema-migration/arango-search-helpers';
-import { Clock, DefaultClock } from '../../execution/execution-options';
+import { Clock, DefaultClock, IDGenerator, UUIDGenerator } from '../../execution/execution-options';
 
 enum AccessType {
     /**
@@ -112,6 +112,11 @@ export interface QueryGenerationOptions {
      * An interface to determine the current date/time
      */
     readonly clock: Clock;
+
+    /**
+     * An interface to generate IDs, e.g. for new child entities.
+     */
+    readonly idGenerator: IDGenerator;
 }
 
 class QueryContext {
@@ -1903,6 +1908,7 @@ export function getAQLQuery(
         undefined,
         new QueryContext({
             clock: options.clock ?? new DefaultClock(),
+            idGenerator: options.idGenerator ?? new UUIDGenerator(),
         }),
     );
 }

--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -56,6 +56,7 @@ import {
     TypeCheckQueryNode,
     UnaryOperationQueryNode,
     UnaryOperator,
+    UpdateChildEntitiesQueryNode,
     UpdateEntitiesQueryNode,
     VariableAssignmentQueryNode,
     VariableQueryNode,
@@ -804,6 +805,56 @@ register(AggregationQueryNode, (node, context) => {
             ? aql`COLLECT ${aggregationVar} = ${itemFrag}`
             : aql``,
         aql`RETURN ${resultFragment}`,
+    );
+});
+
+register(UpdateChildEntitiesQueryNode, (node, context) => {
+    const itemsVar = aql.variable('items');
+    const itemsWithIndexVar = aql.variable('itemsWithIndex');
+    const childContext = context.introduceVariable(node.dictionaryVar);
+    const dictVar = childContext.getVariable(node.dictionaryVar);
+    const updatedDictVar = aql.variable('updatedDict');
+    const itemVar = aql.variable('item');
+    const indexVar = aql.variable('indexVar');
+
+    return aqlExt.parenthesizeList(
+        // could be a complex expression, and we're using it multiple times -> store in a variable
+        aql`LET ${itemsVar} = ${processNode(node.originalList, context)}`,
+
+        // add a __index property to each item so we can sort by this later
+        // regular field names cannot start with an underscore, so we're safe to use __index as a
+        // temporary property to store the index of the child entity in the list
+        aql`LET ${itemsWithIndexVar} = ${aqlExt.parenthesizeList(
+            aql`FOR ${indexVar}`,
+            aql`IN 0..(LENGTH(${itemsVar}) - 1)`,
+            aql`RETURN MERGE(NTH(${itemsVar}, ${indexVar}), { __index: ${indexVar} })`,
+        )}`,
+
+        // convert the list into a dict object like { 'id1': { ...}, 'id2': { ... } }
+        // this allows us to efficiently look up individual objects (to avoid quadratic runtime)
+        aql`LET ${dictVar} = ZIP(${itemsVar}[*].id, ${itemsWithIndexVar})`,
+
+        // merging the updated items into the dict to remove the old versions of the updated items
+        aql`LET ${updatedDictVar} = MERGE(${dictVar}, {`,
+        aql.indent(
+            aql.join(
+                node.updates.map((update): AQLFragment => {
+                    const idFrag = processNode(update.idNode, childContext);
+                    // we're expecting the newChildEntityNode to merge the untouched properties of
+                    // the old item, including __index
+                    const valueFrag = processNode(update.newChildEntityNode, childContext);
+                    return aql`${idFrag}: ${valueFrag}`;
+                }),
+                aql`,\n`,
+            ),
+        ),
+        aql`})`,
+
+        // sort by the __index we stored, and unpack the dictionary into a list again
+        aql`FOR ${itemVar}`,
+        aql`IN VALUES(${updatedDictVar})`,
+        aql`SORT ${itemVar}.__index`,
+        aql`RETURN UNSET(${itemVar}, '__index')`,
     );
 });
 

--- a/src/database/arangodb/arangodb-adapter.ts
+++ b/src/database/arangodb/arangodb-adapter.ts
@@ -333,6 +333,7 @@ export class ArangoDBAdapter implements DatabaseAdapter {
             //TODO Execute single statement AQL queries directly without "db.transaction"?
             aqlQuery = getAQLQuery(queryTree, {
                 clock: options.clock,
+                idGenerator: options.idGenerator,
             });
             executableQueries = aqlQuery.getExecutableQueries();
         } finally {

--- a/src/database/inmemory/js-generator.ts
+++ b/src/database/inmemory/js-generator.ts
@@ -53,6 +53,7 @@ import {
     TypeCheckQueryNode,
     UnaryOperationQueryNode,
     UnaryOperator,
+    UpdateChildEntitiesQueryNode,
     UpdateEntitiesQueryNode,
     VariableAssignmentQueryNode,
     VariableQueryNode,
@@ -506,6 +507,68 @@ register(AggregationQueryNode, (node, context) => {
         default:
             throw new Error(`Unsupported aggregation operator: ${(node as any).operator}`);
     }
+});
+
+register(UpdateChildEntitiesQueryNode, (node, context) => {
+    if (!node.updates.length) {
+        // optimization, and we later rely on updates.length >= 1
+        return processNode(node.originalList, context);
+    }
+
+    const itemsVar = js.variable('items');
+    const childContext = context.introduceVariable(node.dictionaryVar);
+    const dictVar = childContext.getVariable(node.dictionaryVar);
+    const updatedDictVar = js.variable('updatedDict');
+    const itemVar = js.variable('item');
+    const indexVar = js.variable('indexVar');
+
+    // this is deliberately close to the aql implementation
+
+    return jsExt.executingFunction(
+        // could be a complex expression, and we're using it multiple times -> store in a variable
+        js`const ${itemsVar} = ${processNode(node.originalList, context)}`,
+
+        // add a __index property to each item so we can sort by this later
+        // regular field names cannot start with an underscore, so we're safe to use __index as a
+        // temporary property to store the index of the child entity in the list
+        // convert the list into a dict object like { 'id1': { ...}, 'id2': { ... } }
+        // this allows us to efficiently look up individual objects (to avoid quadratic runtime)
+        js`const ${dictVar} = Object.fromEntries(`,
+        js.indent(
+            js.lines(
+                js`${itemsVar}.map((${itemVar}, ${indexVar}) => [`,
+                js.indent(
+                    js.lines(
+                        // id as key, item with __index as value
+                        js`${itemVar}.id,`,
+                        js`{ ...${itemVar}, __index: ${indexVar} }`,
+                    ),
+                ),
+                js`])`,
+            ),
+        ),
+        js`);`,
+
+        // merging the updated items into the dict to remove the old versions of the updated items
+        js`const ${updatedDictVar} = {`,
+        js.indent(
+            js.lines(
+                js`...${dictVar},`,
+                ...node.updates.map((update): JSFragment => {
+                    const idFrag = processNode(update.idNode, childContext);
+                    // we're expecting the newChildEntityNode to merge the untouched properties of
+                    // the old item, including __index
+                    // using [idFrag] because it's a bound value, not an identifier
+                    const valueFrag = processNode(update.newChildEntityNode, childContext);
+                    return js`[${idFrag}]: ${valueFrag},`;
+                }),
+            ),
+        ),
+        js`};`,
+
+        // sort by the __index we stored, and unpack the dictionary into a list again
+        js`return Object.values(${updatedDictVar}).map(({ __index, ...${itemVar} }) => ${itemVar});`,
+    );
 });
 
 register(MergeObjectsQueryNode, (node, context) => {

--- a/src/execution/execution-options.ts
+++ b/src/execution/execution-options.ts
@@ -1,5 +1,6 @@
 import { OperationDefinitionNode } from 'graphql';
 import { AuthContext } from '../authorization/auth-basics';
+import { randomUUID } from 'crypto';
 
 export type MutationMode = 'normal' | 'disallowed' | 'rollback';
 
@@ -90,6 +91,12 @@ export interface ExecutionOptions {
      * An interface to determine the current date/time. If not specified, system time is used
      */
     readonly clock?: Clock;
+
+    /**
+     * An interface to generate IDs, e.g. for new child entities. If not specified, random UUIDs
+     * will be used.
+     */
+    readonly idGenerator?: IDGenerator;
 }
 
 export interface TimeToLiveExecutionOptions {
@@ -144,5 +151,27 @@ export interface Clock {
 export class DefaultClock implements Clock {
     getCurrentTimestamp(): string {
         return new Date().toISOString();
+    }
+}
+
+export type IDGenerationTarget = 'root-entity' | 'child-entity';
+
+export interface IDGenerationInfo {
+    readonly target: IDGenerationTarget;
+}
+
+export interface IDGenerator {
+    /**
+     * Generate an id that will be used for some entities (e.g. child entities)
+     */
+    generateID(info: IDGenerationInfo): string;
+}
+
+export class UUIDGenerator implements IDGenerator {
+    /**
+     * Generates a random UUID
+     */
+    generateID(): string {
+        return randomUUID();
     }
 }

--- a/src/execution/execution-options.ts
+++ b/src/execution/execution-options.ts
@@ -68,6 +68,14 @@ export interface ExecutionOptions {
      */
     readonly flexSearchRecursionDepth?: number;
 
+    /**
+     * A child entity update operation with this number of updates or more will use the "dict"
+     * strategy that converts the list into a dictionary before applying the updates first
+     *
+     * If not specified, a reasonable default will be used
+     */
+    readonly childEntityUpdatesViaDictStrategyThreshold?: number;
+
     readonly timeToLiveOptions?: TimeToLiveExecutionOptions;
 
     /**

--- a/src/execution/operation-resolver.ts
+++ b/src/execution/operation-resolver.ts
@@ -100,6 +100,8 @@ export class OperationResolver {
                 flexSearchMaxFilterableAmountOverride:
                     options.flexSearchMaxFilterableAndSortableAmount,
                 flexSearchRecursionDepth: options.flexSearchRecursionDepth,
+                childEntityUpdatesViaDictStrategyThreshold:
+                    options.childEntityUpdatesViaDictStrategyThreshold,
                 clock: options.clock ?? new DefaultClock(),
                 idGenerator: options.idGenerator ?? new UUIDGenerator(),
             };

--- a/src/execution/operation-resolver.ts
+++ b/src/execution/operation-resolver.ts
@@ -32,7 +32,7 @@ import {
 } from '../schema-generation/query-node-object-type';
 import { SchemaTransformationContext } from '../schema/preparation/transformation-pipeline';
 import { getPreciseTime, Watch } from '../utils/watch';
-import { DefaultClock, ExecutionOptions } from './execution-options';
+import { DefaultClock, ExecutionOptions, UUIDGenerator } from './execution-options';
 import { ExecutionResult } from './execution-result';
 
 export class OperationResolver {
@@ -101,6 +101,7 @@ export class OperationResolver {
                     options.flexSearchMaxFilterableAndSortableAmount,
                 flexSearchRecursionDepth: options.flexSearchRecursionDepth,
                 clock: options.clock ?? new DefaultClock(),
+                idGenerator: options.idGenerator ?? new UUIDGenerator(),
             };
             queryTree = buildConditionalObjectQueryNode(
                 rootQueryNode,

--- a/src/query-tree/child-entities.ts
+++ b/src/query-tree/child-entities.ts
@@ -1,0 +1,90 @@
+import { QueryNode } from './base';
+import { VariableQueryNode } from './variables';
+import { indent } from '../utils/utils';
+
+export interface UpdateChildEntitiesQueryNodeParams {
+    /**
+     * The original list of child entities
+     */
+    readonly originalList: QueryNode;
+
+    /**
+     * A variable to use as a dictionary for existing child entities
+     *
+     * This variable will be set to an object like { id1: childEntity1, id2: childEntity2 }. The
+     * updateQueryNode can use a DynamicPropertyAccessQueryNode(dictionaryVar, id) to access the old
+     * child entity
+     */
+    readonly dictionaryVar: VariableQueryNode;
+
+    /**
+     * The list of child entity updates
+     *
+     * A PropertyAccessQueryNode(dictionaryVar, id) can be used to access the old value for the
+     * respective DynamicPropertyAccessQueryNode entity
+     */
+    readonly updates: ReadonlyArray<ChildEntityUpdate>;
+}
+
+export interface ChildEntityUpdate {
+    /**
+     * A node that evaluates to the child entity id
+     */
+    readonly idNode: QueryNode;
+
+    /**
+     * A node that evaluates to the new value of the child entity
+     */
+    readonly newChildEntityNode: QueryNode;
+}
+
+/**
+ * Updates multiple objects in a list, each identified by an "id" field
+ */
+export class UpdateChildEntitiesQueryNode extends QueryNode {
+    /**
+     * The original list of child entities
+     */
+    readonly originalList: QueryNode;
+
+    /**
+     * A variable to use as a dictionary for existing child entities
+     *
+     * This variable will be set to an object like { id1: childEntity1, id2: childEntity2 }. The
+     * updateQueryNode can use a DynamicPropertyAccessQueryNode(dictionaryVar, id) to access the old
+     * child entity
+     */
+    readonly dictionaryVar: VariableQueryNode;
+
+    /**
+     * The list of child entity updates
+     *
+     * A PropertyAccessQueryNode(dictionaryVar, id) can be used to access the old value for the
+     * respective DynamicPropertyAccessQueryNode entity
+     */
+    readonly updates: ReadonlyArray<ChildEntityUpdate>;
+
+    constructor(params: UpdateChildEntitiesQueryNodeParams) {
+        super();
+        this.originalList = params.originalList;
+        this.dictionaryVar = params.dictionaryVar;
+        this.updates = params.updates;
+    }
+
+    describe() {
+        return (
+            `update child entity list (\n` +
+            indent(this.originalList.describe()) +
+            '\n)' +
+            `with the following updates:\n` +
+            indent(
+                this.updates
+                    .map(
+                        (update) =>
+                            `${update.idNode.describe()}: ${update.newChildEntityNode.describe()}`,
+                    )
+                    .join('\n'),
+            )
+        );
+    }
+}

--- a/src/query-tree/index.ts
+++ b/src/query-tree/index.ts
@@ -12,5 +12,6 @@ export * from './validation';
 export * from './variables';
 export { FlexSearchStartsWithQueryNode } from './flex-search';
 export * from './billing';
+export * from './child-entities';
 
 // visitor is intentionally not re-exported as it can be seen as an 'add-on'

--- a/src/schema-generation/create-input-types/input-types.ts
+++ b/src/schema-generation/create-input-types/input-types.ts
@@ -228,7 +228,7 @@ export class CreateChildEntityInputType extends CreateObjectInputType {
     getAdditionalProperties(value: PlainObject, context: FieldContext) {
         const now = context.clock.getCurrentTimestamp();
         return {
-            [ID_FIELD]: uuid(),
+            [ID_FIELD]: context.idGenerator.generateID({ target: 'child-entity' }),
             [ENTITY_CREATED_AT]: now,
             [ENTITY_UPDATED_AT]: now,
         };

--- a/src/schema-generation/query-node-object-type/context.ts
+++ b/src/schema-generation/query-node-object-type/context.ts
@@ -20,6 +20,14 @@ export interface FieldContext {
     readonly flexSearchRecursionDepth?: number;
 
     /**
+     * A child entity update operation with this number of updates or more will use the "dict"
+     * strategy that converts the list into a dictionary before applying the updates first
+     *
+     * If not specified, a reasonable default will be used
+     */
+    readonly childEntityUpdatesViaDictStrategyThreshold?: number;
+
+    /**
      * A stack of objects that correspond to the selections that are intended to be used with WeakMaps to store
      * additional information
      */

--- a/src/schema-generation/query-node-object-type/context.ts
+++ b/src/schema-generation/query-node-object-type/context.ts
@@ -1,5 +1,5 @@
 import { FieldSelection } from '../../graphql/query-distiller';
-import { Clock } from '../../execution/execution-options';
+import { Clock, IDGenerator } from '../../execution/execution-options';
 
 /**
  * A token that corresponds to a FieldSelection but is local to one execution
@@ -37,4 +37,9 @@ export interface FieldContext {
      * An interface to determine the current date/time
      */
     readonly clock: Clock;
+
+    /**
+     * An interface to generate IDs, e.g. for new child entities
+     */
+    readonly idGenerator: IDGenerator;
 }

--- a/src/schema-generation/query-node-object-type/query-node-generator.ts
+++ b/src/schema-generation/query-node-object-type/query-node-generator.ts
@@ -21,7 +21,7 @@ import { decapitalize, flatMap } from '../../utils/utils';
 import { FieldContext, SelectionToken } from './context';
 import { QueryNodeField, QueryNodeObjectType } from './definition';
 import { extractQueryTreeObjectType, isListTypeIgnoringNonNull } from './utils';
-import { DefaultClock } from '../../execution/execution-options';
+import { DefaultClock, UUIDGenerator } from '../../execution/execution-options';
 
 export function createRootFieldContext(
     options: Partial<
@@ -33,6 +33,7 @@ export function createRootFieldContext(
         selectionTokenStack: [],
         selectionToken: new SelectionToken(),
         clock: options.clock ?? new DefaultClock(),
+        idGenerator: options.idGenerator ?? new UUIDGenerator(),
         ...options,
     };
 }


### PR DESCRIPTION
perf: improve performance of bulk child entity updates and avoid hitting the AQL limit of 500 nesting limit doing it

Child entity updates generate a lot of AQL because each entity can have different kinds of updates, and some of them refer to old values. This is still the case after the optimizations.

However, previously, we performed multiple child entity updates by nesting conditional expressions like this:

```
items = items.map(item =>
  item.id == 2 ? update2(item) : (item.id == 1 ? update1(item) : item)
);
```

This generated one level of nesting per update. ArangoDB 3.11 now limits the AQL nesting to 500, which means we would be limited to a little under 500 item updates in one mutation. In addition, a few hundred updates had realy bad performance.

Now, we convert the list into a dictionary (id -> entity), so we can more efficiently look up items and construct the new list.

This optimization is only applied after a threshold of 3 (configurable) because it involves some steps, and doing a single or two updates is probably still faster with the conditionals.