### PR TITLE
fix: treat DOCUMENT() calls as implicit collection reads

### DIFF
--- a/src/database/arangodb/aql-generator.ts
+++ b/src/database/arangodb/aql-generator.ts
@@ -486,7 +486,10 @@ register(WithPreExecutionQueryNode, (node, context) => {
 });
 
 register(EntityFromIdQueryNode, (node, context) => {
-    const collection = getCollectionForType(node.rootEntityType, AccessType.EXPLICIT_READ, context);
+    // the DOCUMENT() function only dynamically refers to the collection name, so the coordinators
+    // do not know about the collections. Therefore, these are implicit reads.
+    // We should refactor DOCUMENT() to collection traversals in the future to enable optimizations.
+    const collection = getCollectionForType(node.rootEntityType, AccessType.IMPLICIT_READ, context);
     return aql`DOCUMENT(${collection}, ${processNode(node.idNode, context)})`;
 });
 


### PR DESCRIPTION
Since ArangoDB 3.10, it is necessary to include start vertex collections in the WITH statement for cluster operation, and we might use EntityFromIdQueryNode somewhere for start vertices.