### PR TITLE
feat: add raw localizations to meta types, fields and enums

### DIFF
--- a/spec/dev/model/i18n.yml
+++ b/spec/dev/model/i18n.yml
@@ -1,6 +1,13 @@
 i18n:
   en:
     types:
+      Morality:
+        label: Morality
+        labelPlural: Morality
+        hint: The morality of the hero
+        values:
+          GOOD: Good
+          EVIL: Evil
       Hero:
         label: Hero
         labelPlural: Heroes
@@ -22,6 +29,14 @@ i18n:
       id: ID
   de:
     types:
+      Morality:
+        label: Moral
+        labelPlural: Moral
+        hint: Die Moral des Helden
+        values:
+          GOOD: Gut
+          EVIL: Böse
+
       Hero:
         label: Held
         labelPlural: Helden

--- a/spec/model/create-model.spec.ts
+++ b/spec/model/create-model.spec.ts
@@ -185,4 +185,172 @@ describe('createModel', () => {
         expect(field.isFlexSearchIndexed).to.be.true;
         expect(field.isIncludedInSearch).to.be.false;
     });
+
+    it('it allows to access raw label/labelPlural/hint localization on type "ObjectType" and its fields', () => {
+        const document: DocumentNode = gql`
+            type Shipment @rootEntity {
+                shipmentNumber: String
+            }
+        `;
+        const model = createSimpleModel(document, {
+            de: {
+                namespacePath: [],
+                types: {
+                    Shipment: {
+                        label: 'Lieferung',
+                        labelPlural: 'Lieferungen',
+                        hint: 'Eine Lieferung',
+                        fields: {
+                            shipmentNumber: {
+                                label: 'Lieferungsnummer',
+                                hint: 'Die Nummer der Lieferung',
+                            },
+                        },
+                    },
+                },
+            },
+            en: {
+                namespacePath: [],
+                types: {
+                    Shipment: {
+                        label: 'Shipment',
+                        labelPlural: 'Shipments',
+                        hint: 'A shipment',
+                        fields: {
+                            shipmentNumber: {
+                                label: 'Shipment number',
+                                hint: 'The number of the shipment',
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        const shipmentType = model.getObjectTypeOrThrow('Shipment');
+        expect(shipmentType.label).to.deep.equal({
+            de: 'Lieferung',
+            en: 'Shipment',
+        });
+        expect(shipmentType.labelPlural).to.deep.equal({
+            de: 'Lieferungen',
+            en: 'Shipments',
+        });
+        expect(shipmentType.hint).to.deep.equal({
+            de: 'Eine Lieferung',
+            en: 'A shipment',
+        });
+        const shipmentNumberField = shipmentType.getFieldOrThrow('shipmentNumber');
+        expect(shipmentNumberField.label).to.deep.equal({
+            de: 'Lieferungsnummer',
+            en: 'Shipment number',
+        });
+        expect(shipmentNumberField.hint).to.deep.equal({
+            de: 'Die Nummer der Lieferung',
+            en: 'The number of the shipment',
+        });
+    });
+
+    it('it allows to access raw label/labelPlural/hint localization on type "EnumType" and its values', () => {
+        const document: DocumentNode = gql`
+            type Shipment @rootEntity {
+                transportKind: TransportKind
+            }
+
+            enum TransportKind {
+                AIR
+                SEA
+                ROAD
+            }
+        `;
+        const model = createSimpleModel(document, {
+            de: {
+                namespacePath: [],
+                types: {
+                    TransportKind: {
+                        label: 'Transportart',
+                        labelPlural: 'Transportarten',
+                        hint: 'Die Art des Transports',
+                        values: {
+                            AIR: {
+                                label: 'Luft',
+                                hint: 'Lieferung mittels Fluchtfracht',
+                            },
+                            ROAD: {
+                                label: 'Straße',
+                                hint: 'Lieferung mittels LKW',
+                            },
+                            SEA: {
+                                label: 'Übersee',
+                                hint: 'Lieferung mittels Schiff',
+                            },
+                        },
+                    },
+                },
+            },
+            en: {
+                namespacePath: [],
+                types: {
+                    TransportKind: {
+                        label: 'Transport kind',
+                        labelPlural: 'Transport kinds',
+                        hint: 'The kind of transport',
+                        values: {
+                            AIR: {
+                                label: 'Air',
+                                hint: 'Delivery via airfreight',
+                            },
+                            ROAD: {
+                                label: 'Road',
+                                hint: 'Delivery via truck',
+                            },
+                            SEA: {
+                                label: 'Sea',
+                                hint: 'Delivery via ship',
+                            },
+                        },
+                    },
+                },
+            },
+        });
+        const transportKindType = model.getEnumTypeOrThrow('TransportKind');
+        expect(transportKindType.label).to.deep.equal({
+            de: 'Transportart',
+            en: 'Transport kind',
+        });
+        expect(transportKindType.labelPlural).to.deep.equal({
+            de: 'Transportarten',
+            en: 'Transport kinds',
+        });
+        expect(transportKindType.hint).to.deep.equal({
+            de: 'Die Art des Transports',
+            en: 'The kind of transport',
+        });
+        const valueAIR = transportKindType.values.find((value) => value.value === 'AIR');
+        const valueROAD = transportKindType.values.find((value) => value.value === 'ROAD');
+        const valueSEA = transportKindType.values.find((value) => value.value === 'SEA');
+        expect(valueAIR?.label).to.deep.equal({
+            de: 'Luft',
+            en: 'Air',
+        });
+        expect(valueAIR?.hint).to.deep.equal({
+            de: 'Lieferung mittels Fluchtfracht',
+            en: 'Delivery via airfreight',
+        });
+        expect(valueROAD?.label).to.deep.equal({
+            de: 'Straße',
+            en: 'Road',
+        });
+        expect(valueROAD?.hint).to.deep.equal({
+            de: 'Lieferung mittels LKW',
+            en: 'Delivery via truck',
+        });
+        expect(valueSEA?.label).to.deep.equal({
+            de: 'Übersee',
+            en: 'Sea',
+        });
+        expect(valueSEA?.hint).to.deep.equal({
+            de: 'Lieferung mittels Schiff',
+            en: 'Delivery via ship',
+        });
+    });
 });

--- a/spec/model/model-spec.helper.ts
+++ b/spec/model/model-spec.helper.ts
@@ -1,8 +1,20 @@
 import { DocumentNode } from 'graphql';
-import { ParsedProject, ParsedProjectSourceBaseKind } from '../../src/config/parsed-project';
-import { createModel, Model, PermissionProfileConfigMap } from '../../src/model';
+import {
+    ParsedProject,
+    ParsedProjectSource,
+    ParsedProjectSourceBaseKind,
+} from '../../src/config/parsed-project';
+import {
+    createModel,
+    Model,
+    NamespaceLocalizationConfig,
+    PermissionProfileConfigMap,
+} from '../../src/model';
 
-export function createSimpleModel(document: DocumentNode): Model {
+export function createSimpleModel(
+    document: DocumentNode,
+    i18n?: Record<string, NamespaceLocalizationConfig>,
+): Model {
     const permissionProfiles: PermissionProfileConfigMap = {
         default: {
             permissions: [
@@ -26,6 +38,16 @@ export function createSimpleModel(document: DocumentNode): Model {
                 object: { permissionProfiles },
                 pathLocationMap: {},
             },
+            ...(i18n
+                ? [
+                      {
+                          kind: ParsedProjectSourceBaseKind.OBJECT,
+                          namespacePath: [],
+                          object: { i18n },
+                          pathLocationMap: {},
+                      } as ParsedProjectSource,
+                  ]
+                : []),
         ],
     };
     return createModel(parsedProject);

--- a/src/model/implementation/enum-type.ts
+++ b/src/model/implementation/enum-type.ts
@@ -5,6 +5,7 @@ import { ModelComponent } from '../validation/validation-context';
 import { EnumValueLocalization } from './i18n';
 import { Model } from './model';
 import { TypeBase } from './type-base';
+import memorize from 'memorize-decorator';
 
 export class EnumType extends TypeBase {
     constructor(input: EnumTypeConfig, model: Model) {
@@ -36,12 +37,14 @@ export class EnumValue implements ModelComponent {
     readonly description: string | undefined;
     readonly deprecationReason: string | undefined;
     readonly astNode: EnumValueDefinitionNode | undefined;
+    readonly model: Model;
 
     constructor(input: EnumValueConfig, public readonly declaringType: EnumType) {
         this.value = input.value;
         this.description = input.description;
         this.deprecationReason = input.deprecationReason;
         this.astNode = input.astNode;
+        this.model = declaringType.model;
     }
 
     public getLocalization(resolutionOrder: ReadonlyArray<string>): EnumValueLocalization {
@@ -63,5 +66,27 @@ export class EnumValue implements ModelComponent {
                 ValidationMessage.warn(`Enum values should be UPPER_CASE.`, this.astNode),
             );
         }
+    }
+
+    @memorize()
+    get label(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getEnumValueI18n(this))) {
+            if (localization.label) {
+                res[lang] = localization.label;
+            }
+        }
+        return res;
+    }
+
+    @memorize()
+    get hint(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getEnumValueI18n(this))) {
+            if (localization.hint) {
+                res[lang] = localization.hint;
+            }
+        }
+        return res;
     }
 }

--- a/src/model/implementation/field.ts
+++ b/src/model/implementation/field.ts
@@ -159,6 +159,28 @@ export class Field implements ModelComponent {
     }
 
     @memorize()
+    get label(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getFieldI18n(this))) {
+            if (localization.label) {
+                res[lang] = localization.label;
+            }
+        }
+        return res;
+    }
+
+    @memorize()
+    get hint(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getFieldI18n(this))) {
+            if (localization.hint) {
+                res[lang] = localization.hint;
+            }
+        }
+        return res;
+    }
+
+    @memorize()
     public get permissionProfile(): PermissionProfile | undefined {
         if (!this.input.permissions || this.input.permissions.permissionProfileName == undefined) {
             return undefined;

--- a/src/model/implementation/i18n.ts
+++ b/src/model/implementation/i18n.ts
@@ -1,4 +1,4 @@
-import { I18N_GENERIC } from '../../meta-schema/constants';
+import { I18N_GENERIC, I18N_LOCALE } from '../../meta-schema/constants';
 import {
     arrayStartsWith,
     capitalize,
@@ -62,6 +62,12 @@ export class ModelI18n implements ModelComponent {
         };
     }
 
+    public getTypeI18n(type: TypeBase): Record<string, TypeLocalization> {
+        return mapValues(this.getAllLocalizationProviders(), (provider) =>
+            provider.localizeType(type),
+        );
+    }
+
     public getFieldLocalization(
         field: Field,
         resolutionOrder: ReadonlyArray<string>,
@@ -73,6 +79,12 @@ export class ModelI18n implements ModelComponent {
             label: mapFirstDefined(resolutionProviders, (rp) => rp.localizeField(field).label),
             hint: mapFirstDefined(resolutionProviders, (rp) => rp.localizeField(field).hint),
         };
+    }
+
+    public getFieldI18n(field: Field): Record<string, FieldLocalization> {
+        return mapValues(this.getAllLocalizationProviders(), (provider) =>
+            provider.localizeField(field),
+        );
     }
 
     public getEnumValueLocalization(
@@ -92,6 +104,12 @@ export class ModelI18n implements ModelComponent {
         };
     }
 
+    public getEnumValueI18n(enumValue: EnumValue): Record<string, EnumValueLocalization> {
+        return mapValues(this.getAllLocalizationProviders(), (provider) =>
+            provider.localizeEnumValue(enumValue),
+        );
+    }
+
     private getResolutionProviders(
         resolutionOrder: ReadonlyArray<string>,
     ): ReadonlyArray<LocalizationProvider> {
@@ -105,6 +123,18 @@ export class ModelI18n implements ModelComponent {
                 }
             }),
         );
+    }
+
+    /**
+     * Returns all available localization providers.
+     *
+     * The derived languages "I18N_GENERIC" and "I18N_LOCALE" are not included.
+     */
+    private getAllLocalizationProviders(): Record<string, LocalizationProvider> {
+        const filteredProviders = Array.from(
+            this.languageLocalizationProvidersByLanguage.entries(),
+        ).filter(([lang, _]) => lang !== I18N_GENERIC && lang !== I18N_LOCALE);
+        return Object.fromEntries(filteredProviders);
     }
 }
 
@@ -214,11 +244,8 @@ export class NamespaceLocalization {
     }
 }
 
-export interface TypeLocalization {
-    readonly label?: string;
+export interface TypeLocalization extends LocalizationBaseConfig {
     readonly labelPlural?: string;
-    readonly hint?: string;
-    readonly loc?: MessageLocation;
 }
 
 export interface FieldLocalization extends LocalizationBaseConfig {}

--- a/src/model/implementation/object-type-base.ts
+++ b/src/model/implementation/object-type-base.ts
@@ -1,6 +1,6 @@
 import { groupBy } from 'lodash';
 import { objectValues } from '../../utils/utils';
-import { FieldConfig, ObjectTypeConfig } from '../config';
+import { ObjectTypeConfig } from '../config';
 import { ValidationContext, ValidationMessage } from '../validation';
 import { Field, SystemFieldConfig } from './field';
 import { Model } from './model';

--- a/src/model/implementation/type-base.ts
+++ b/src/model/implementation/type-base.ts
@@ -80,6 +80,39 @@ export abstract class TypeBase implements ModelComponent {
         return this.model.getNamespaceByPathOrThrow(this.namespacePath);
     }
 
+    @memorize()
+    get label(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getTypeI18n(this))) {
+            if (localization.label) {
+                res[lang] = localization.label;
+            }
+        }
+        return res;
+    }
+
+    @memorize()
+    get labelPlural(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getTypeI18n(this))) {
+            if (localization.labelPlural) {
+                res[lang] = localization.labelPlural;
+            }
+        }
+        return res;
+    }
+
+    @memorize()
+    get hint(): Record<string, string> {
+        const res: Record<string, string> = {};
+        for (const [lang, localization] of Object.entries(this.model.i18n.getTypeI18n(this))) {
+            if (localization.hint) {
+                res[lang] = localization.hint;
+            }
+        }
+        return res;
+    }
+
     abstract readonly isObjectType: boolean;
     abstract readonly isRootEntityType: boolean;
     abstract readonly isChildEntityType: boolean;


### PR DESCRIPTION
Currently, it is only possible to query localizations by explicitly specifying the target language for the client. There are also use-cases where the localization is not immediately used in a client, but needed to be processed in another system. In this case it is convenient to be able to query the translations in all locales in a single request.