### PR TITLE
fix: do not make "Field is missing" suppressable on type level

### DIFF
--- a/src/model/compatibility-check/check-key-field.ts
+++ b/src/model/compatibility-check/check-key-field.ts
@@ -22,14 +22,14 @@ export function checkKeyField(
         // special case: If the baseline requires id: ID @key, the fieldToCheck might not be authored at all
         // (because it's an automatic system field). We need to tell the user that the field needs to be added.
         if (fieldToCheck.isSystemField && fieldToCheck.name === ID_FIELD && !fieldToCheck.astNode) {
+            // we currently can't suppress missing fields in general. Rather than adding a special
+            // code for "id", wait until we have a way to suppress missing fields in general.
             context.addMessage(
-                ValidationMessage.suppressableCompatibilityIssue(
-                    'MISSING_FIELD',
+                ValidationMessage.nonSuppressableCompatibilityIssue(
                     `Field "id: ID @key" needs to be specified${getRequiredBySuffix(
                         baselineField,
                     )}.`,
-                    fieldToCheck.declaringType.astNode,
-                    { location: fieldToCheck.declaringType.nameASTNode },
+                    fieldToCheck.declaringType.nameASTNode ?? fieldToCheck.declaringType.astNode,
                 ),
             );
         } else {

--- a/src/model/compatibility-check/check-object-type.ts
+++ b/src/model/compatibility-check/check-object-type.ts
@@ -48,14 +48,15 @@ export function checkObjectType(
                 );
             }
 
+            // cannot easily make this suppressable - if we would accept a @suppress on the type,
+            // that would supress all missing fields, not just this one
             context.addMessage(
-                ValidationMessage.suppressableCompatibilityIssue(
-                    'MISSING_FIELD',
+                ValidationMessage.nonSuppressableCompatibilityIssue(
                     `Field "${baselineType.name}.${
                         baselineField.name
                     }" is missing${getRequiredBySuffix(baselineField)}.`,
-                    typeToCheck.astNode,
-                    { location: typeToCheck.nameASTNode, quickFixes },
+                    typeToCheck.nameASTNode ?? typeToCheck.astNode,
+                    { quickFixes },
                 ),
             );
             continue;

--- a/src/model/validation/suppress/message-codes.ts
+++ b/src/model/validation/suppress/message-codes.ts
@@ -47,7 +47,6 @@ export const COMPATIBILITY_ISSUE_CODES = {
     DEFAULT_VALUE: 'Missing, superfluous or diverging @defaultValue',
     MISSING_ENUM_VALUE: 'An enum declaration is missing a value',
     FIELD_TYPE: 'A field has the wrong type',
-    MISSING_FIELD: 'An object type declaration is missing a field',
     KEY_FIELD: 'Missing or superfluous @key',
     REFERENCE: 'Missing, superfluous or diverging @reference',
     RELATION: 'Missing, superfluous or diverging @relation',


### PR DESCRIPTION
It suppressed all missing fields, not just the one, which does not make sense.