### PR TITLE
refactor: only include "required by modules" suffix for checks that are module-specific

### DIFF
--- a/spec/model/compatibility-check/check-business-object.spec.ts
+++ b/spec/model/compatibility-check/check-business-object.spec.ts
@@ -22,7 +22,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Type "Test" needs to be decorated with @businessObject (required by module "module1").',
+                'Type "Test" needs to be decorated with @businessObject.',
             );
         });
 

--- a/spec/model/compatibility-check/check-calc-mutations.spec.ts
+++ b/spec/model/compatibility-check/check-calc-mutations.spec.ts
@@ -22,7 +22,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.test" should be decorated with @calcMutations(operators: [ADD]) (required by module "module1").',
+                'Field "Test.test" should be decorated with @calcMutations(operators: [ADD]).',
             );
         });
 
@@ -41,7 +41,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.test" should be decorated with @calcMutations(operators: [ADD, MULTIPLY]) (required by module "module1").',
+                'Field "Test.test" should be decorated with @calcMutations(operators: [ADD, MULTIPLY]).',
             );
         });
 
@@ -58,10 +58,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Operator MULTIPLY is missing (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Operator MULTIPLY is missing.');
         });
 
         it('rejects three missing operators', () => {
@@ -79,7 +76,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Operators ADD, SUBTRACT and DIVIDE are missing (required by module "module1").',
+                'Operators ADD, SUBTRACT and DIVIDE are missing.',
             );
         });
 

--- a/spec/model/compatibility-check/check-collect-field.spec.ts
+++ b/spec/model/compatibility-check/check-collect-field.spec.ts
@@ -32,7 +32,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.items2" should not be a collect field (required by module "module1").',
+                'Field "Test.items2" should not be a collect field.',
             );
         });
 
@@ -61,7 +61,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.items2" should be decorated with @collect(path: "items") (required by module "module1").',
+                'Field "Test.items2" should be decorated with @collect(path: "items").',
             );
         });
 
@@ -90,7 +90,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.sum" should be decorated with @collect(path: "items.value", aggregate: SUM) (required by module "module1").',
+                'Field "Test.sum" should be decorated with @collect(path: "items.value", aggregate: SUM).',
             );
         });
 
@@ -119,10 +119,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Path should be "items.value1" (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Path should be "items.value1".');
         });
 
         it('rejects a wrong aggregate argument', () => {
@@ -150,7 +147,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Collect field should specify aggregate: COUNT_NULL (required by module "module1").',
+                'Collect field should specify aggregate: COUNT_NULL.',
             );
         });
 

--- a/spec/model/compatibility-check/check-default-value.spec.ts
+++ b/spec/model/compatibility-check/check-default-value.spec.ts
@@ -27,7 +27,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.field" should not have a default value (required by module "module1").',
+                'Field "Test.field" should not have a default value.',
             );
         });
 
@@ -51,7 +51,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.field" should be decorated with @defaultValue(value: "hello") (required by module "module1").',
+                'Field "Test.field" should be decorated with @defaultValue(value: "hello").',
             );
         });
 
@@ -73,10 +73,7 @@ describe('checkModel', () => {
                     allowWarningsAndInfosInProjectToCheck: true,
                 },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Default value should be "correct" (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Default value should be "correct".');
         });
 
         it('rejects a wrong @defaultValue with an Int type', () => {
@@ -97,10 +94,7 @@ describe('checkModel', () => {
                     allowWarningsAndInfosInProjectToCheck: true,
                 },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Default value should be 42 (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Default value should be 42.');
         });
 
         it('rejects a wrong @defaultValue with a Float type', () => {
@@ -121,10 +115,7 @@ describe('checkModel', () => {
                     allowWarningsAndInfosInProjectToCheck: true,
                 },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Default value should be 6.28 (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Default value should be 6.28.');
         });
 
         it('rejects a wrong @defaultValue with an [Int] type', () => {
@@ -145,10 +136,7 @@ describe('checkModel', () => {
                     allowWarningsAndInfosInProjectToCheck: true,
                 },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Default value should be [1, 2, 3] (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Default value should be [1, 2, 3].');
         });
 
         it('rejects a wrong @defaultValue with a value object type', () => {
@@ -179,10 +167,7 @@ describe('checkModel', () => {
                     allowWarningsAndInfosInProjectToCheck: true,
                 },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Default value should be {a: true, b: false} (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Default value should be {a: true, b: false}.');
         });
 
         it('accepts a correct @defaultValue with a String type', () => {

--- a/spec/model/compatibility-check/check-enums.spec.ts
+++ b/spec/model/compatibility-check/check-enums.spec.ts
@@ -21,10 +21,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Enum value "VALUE2" is missing (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Enum value "VALUE2" is missing.');
         });
 
         it('accepts an additional enum value', () => {

--- a/spec/model/compatibility-check/check-field-type.spec.ts
+++ b/spec/model/compatibility-check/check-field-type.spec.ts
@@ -39,7 +39,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.field" needs to be of type "String" (required by module "module1").',
+                'Field "Test.field" needs to be of type "String".',
             );
             expectQuickFix(
                 result,
@@ -63,10 +63,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Field "Test.field" needs to be a list (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Field "Test.field" needs to be a list.');
             expectQuickFix(
                 result,
                 'Change type to "[String]"',
@@ -89,10 +86,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Field "Test.field" should not be a list (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Field "Test.field" should not be a list.');
             expectQuickFix(
                 result,
                 'Change type to "String"',

--- a/spec/model/compatibility-check/check-flex-search-on-field.spec.ts
+++ b/spec/model/compatibility-check/check-flex-search-on-field.spec.ts
@@ -20,10 +20,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Field "field" should enable @flexSearch (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Field "field" should enable @flexSearch.');
         });
 
         it('accepts @flexSearch is present', () => {
@@ -73,7 +70,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearch(includeInSearch: true) (required by module "module1").',
+                'Field "field" should enable @flexSearch(includeInSearch: true).',
             );
         });
 
@@ -92,7 +89,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearch(includeInSearch: true) (required by module "module1").',
+                'Field "field" should enable @flexSearch(includeInSearch: true).',
             );
         });
 
@@ -145,7 +142,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearchFulltext (required by module "module1").',
+                'Field "field" should enable @flexSearchFulltext.',
             );
         });
 
@@ -164,7 +161,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearchFulltext (required by module "module1").',
+                'Field "field" should enable @flexSearchFulltext.',
             );
         });
 
@@ -215,7 +212,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearch(includeInSearch: true) (required by module "module1").',
+                'Field "field" should enable @flexSearch(includeInSearch: true).',
             );
         });
 
@@ -234,7 +231,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "field" should enable @flexSearch(includeInSearch: true) (required by module "module1").',
+                'Field "field" should enable @flexSearch(includeInSearch: true).',
             );
         });
 

--- a/spec/model/compatibility-check/check-flex-search-on-type.spec.ts
+++ b/spec/model/compatibility-check/check-flex-search-on-type.spec.ts
@@ -20,10 +20,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Type "Test" needs to be enable flexSearch (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Type "Test" needs to be enable flexSearch.');
         });
 
         it('rejects if flexSearch is set to false', () => {
@@ -39,10 +36,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Type "Test" needs to be enable flexSearch (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Type "Test" needs to be enable flexSearch.');
         });
 
         it('accepts if flexSearch is set to true even if not needed', () => {
@@ -81,7 +75,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Type "Test" should specify flexSearchOrder: [{field: "field", direction: ASC}] (required by module "module1").',
+                'Type "Test" should specify flexSearchOrder: [{field: "field", direction: ASC}].',
             );
         });
 
@@ -104,7 +98,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Type "Test" should not specify a custom flexSearchOrder (required by module "module1").',
+                'Type "Test" should not specify a custom flexSearchOrder.',
             );
         });
 
@@ -132,7 +126,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Type "Test" should specify flexSearchOrder: [{field: "field", direction: DESC}] (required by module "module1").',
+                'Type "Test" should specify flexSearchOrder: [{field: "field", direction: DESC}].',
             );
         });
     });

--- a/spec/model/compatibility-check/check-key-field.spec.ts
+++ b/spec/model/compatibility-check/check-key-field.spec.ts
@@ -22,7 +22,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.field" needs to be decorated with @key (required by module "module1").',
+                'Field "Test.field" needs to be decorated with @key.',
             );
         });
         it('accepts if the field is properly decorated with @key', () => {
@@ -55,10 +55,7 @@ describe('checkModel', () => {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Field "id: ID @key" needs to be specified (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Field "id: ID @key" needs to be specified.');
         });
 
         it('rejects if the id field needs to be decorated with @key', () => {
@@ -79,7 +76,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Field "Test.id" needs to be decorated with @key (required by module "module1").',
+                'Field "Test.id" needs to be decorated with @key.',
             );
         });
 

--- a/spec/model/compatibility-check/check-model.spec.ts
+++ b/spec/model/compatibility-check/check-model.spec.ts
@@ -79,10 +79,7 @@ type Test @rootEntity {
                     }
                 `,
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Type "Test" needs to be a root entity type (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Type "Test" needs to be a root entity type.');
         });
     });
 });

--- a/spec/model/compatibility-check/check-reference.spec.ts
+++ b/spec/model/compatibility-check/check-reference.spec.ts
@@ -27,8 +27,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Test.field" should be decorated with @reference(keyField: "keyField") (required by module "module1").',
-                'Field "Test.field" should not be a relation (required by module "module1").',
+                'Field "Test.field" should be decorated with @reference(keyField: "keyField").',
+                'Field "Test.field" should not be a relation.',
             ]);
         });
 
@@ -54,7 +54,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Reference should declare keyField: "keyField" (required by module "module1").',
+                'Reference should declare keyField: "keyField".',
             );
         });
 
@@ -75,10 +75,7 @@ describe('checkModel', () => {
                 `,
                 { allowWarningsAndInfosInBaselineProject: true },
             );
-            expectSingleCompatibilityIssue(
-                result,
-                'Reference should not declare a keyField (required by module "module1").',
-            );
+            expectSingleCompatibilityIssue(result, 'Reference should not declare a keyField.');
         });
 
         it('rejects a wrong @reference(keyField)', () => {
@@ -102,7 +99,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Reference should declare keyField: "keyField" (required by module "module1").',
+                'Reference should declare keyField: "keyField".',
             );
         });
 

--- a/spec/model/compatibility-check/check-relation.spec.ts
+++ b/spec/model/compatibility-check/check-relation.spec.ts
@@ -28,8 +28,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Test.field" should not be a reference (required by module "module1").',
-                'Field "Test.field" should be decorated with @relation (required by module "module1").',
+                'Field "Test.field" should not be a reference.',
+                'Field "Test.field" should be decorated with @relation.',
             ]);
         });
 
@@ -56,8 +56,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Test.backwards" should not be a reference (required by module "module1").',
-                'Field "Test.backwards" should be decorated with @relation(inverseOf: "forwards") (required by module "module1").',
+                'Field "Test.backwards" should not be a reference.',
+                'Field "Test.backwards" should be decorated with @relation(inverseOf: "forwards").',
             ]);
         });
 
@@ -80,8 +80,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Relation "forwards" should be a forward relation, not an inverse relation (required by module "module1").',
-                'Relation "backwards" should be an inverse relation with inverseOf: "forwards" (required by module "module1").',
+                'Relation "forwards" should be a forward relation, not an inverse relation.',
+                'Relation "backwards" should be an inverse relation with inverseOf: "forwards".',
             ]);
         });
 
@@ -109,7 +109,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Relation "backwards" should be an inverse relation with inverseOf: "forwards" (required by module "module1").',
+                'Relation "backwards" should be an inverse relation with inverseOf: "forwards".',
             );
         });
 
@@ -128,7 +128,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Relation "test" should specify onDelete: RESTRICT (required by module "module1").',
+                'Relation "test" should specify onDelete: RESTRICT.',
             );
         });
 
@@ -147,7 +147,7 @@ describe('checkModel', () => {
             );
             expectSingleCompatibilityIssue(
                 result,
-                'Relation "test" should omit the "onDelete" argument (required by module "module1").',
+                'Relation "test" should omit the "onDelete" argument.',
             );
         });
 

--- a/spec/model/compatibility-check/check-root-and-parent-directives.spec.ts
+++ b/spec/model/compatibility-check/check-root-and-parent-directives.spec.ts
@@ -39,8 +39,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Child.root" should not be a reference (required by module "module1").',
-                'Field "Child.root" should be decorated with @root (required by module "module1").',
+                'Field "Child.root" should not be a reference.',
+                'Field "Child.root" should be decorated with @root.',
             ]);
         });
 
@@ -71,8 +71,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Child.root" should be decorated with @reference(keyField: "field") (required by module "module1").',
-                'Field "Child.root" should not be decorated with @root (required by module "module1").',
+                'Field "Child.root" should be decorated with @reference(keyField: "field").',
+                'Field "Child.root" should not be decorated with @root.',
             ]);
         });
 
@@ -130,8 +130,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Child.parent" should not be a reference (required by module "module1").',
-                'Field "Child.parent" should be decorated with @parent (required by module "module1").',
+                'Field "Child.parent" should not be a reference.',
+                'Field "Child.parent" should be decorated with @parent.',
             ]);
         });
 
@@ -162,8 +162,8 @@ describe('checkModel', () => {
             );
             expect(result.messages.length).to.equal(2);
             expect(result.getCompatibilityIssues().map((m) => m.message)).to.deep.equal([
-                'Field "Child.parent" should be decorated with @reference(keyField: "field") (required by module "module1").',
-                'Field "Child.parent" should not be decorated with @parent (required by module "module1").',
+                'Field "Child.parent" should be decorated with @reference(keyField: "field").',
+                'Field "Child.parent" should not be decorated with @parent.',
             ]);
         });
 

--- a/src/model/compatibility-check/check-business-object.ts
+++ b/src/model/compatibility-check/check-business-object.ts
@@ -1,7 +1,5 @@
-import { ObjectType, RootEntityType } from '../implementation';
+import { RootEntityType } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { checkField } from './check-field';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 export function checkBusinessObject(
     typeToCheck: RootEntityType,
@@ -12,9 +10,7 @@ export function checkBusinessObject(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'BUSINESS_OBJECT',
-                `Type "${
-                    baselineType.name
-                }" needs to be decorated with @businessObject${getRequiredBySuffix(baselineType)}.`,
+                `Type "${baselineType.name}" needs to be decorated with @businessObject.`,
                 typeToCheck.astNode,
                 { location: typeToCheck.nameASTNode },
             ),

--- a/src/model/compatibility-check/check-calc-mutations.ts
+++ b/src/model/compatibility-check/check-calc-mutations.ts
@@ -1,7 +1,6 @@
 import { CALC_MUTATIONS_OPERATORS_ARG } from '../../schema/constants';
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether all calc mutations defined in the baseline field are also present in the field to check
@@ -26,9 +25,7 @@ export function checkCalcMutations(
                 'CALC_MUTATIONS',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with ${expectedDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be decorated with ${expectedDeclaration}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -56,7 +53,7 @@ export function checkCalcMutations(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'CALC_MUTATIONS',
-                `${message}${getRequiredBySuffix(baselineField)}.`,
+                `${message}.`,
                 fieldToCheck.astNode,
                 {
                     location: operatorsAstNode ?? fieldToCheck.calcMutationsAstNode,

--- a/src/model/compatibility-check/check-collect-field.ts
+++ b/src/model/compatibility-check/check-collect-field.ts
@@ -1,6 +1,5 @@
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether the @collect directives on the field and on the baseline fields match
@@ -17,7 +16,7 @@ export function checkCollectField(
                 'COLLECT',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be a collect field${getRequiredBySuffix(baselineField)}.`,
+                }" should not be a collect field.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.collectAstNode },
             ),
@@ -45,9 +44,7 @@ export function checkCollectField(
                 'COLLECT',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with ${expectedCollectDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be decorated with ${expectedCollectDeclaration}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -63,9 +60,7 @@ export function checkCollectField(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'COLLECT',
-                `Path should be "${baselineField.collectPath.path}"${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                `Path should be "${baselineField.collectPath.path}".`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.collectPathAstNode ?? fieldToCheck.collectAstNode },
             ),
@@ -78,7 +73,7 @@ export function checkCollectField(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'COLLECT',
-                `No aggregation should be used here${getRequiredBySuffix(baselineField)}.`,
+                `No aggregation should be used here.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.aggregationOperatorAstNode },
             ),
@@ -93,9 +88,7 @@ export function checkCollectField(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'COLLECT',
-                `Collect field should specify ${expectedAggregateDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                `Collect field should specify ${expectedAggregateDeclaration}.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.aggregationOperatorAstNode },
             ),

--- a/src/model/compatibility-check/check-default-value.ts
+++ b/src/model/compatibility-check/check-default-value.ts
@@ -3,7 +3,6 @@ import { print } from 'graphql';
 import { createValueNodeFromValue } from '../../graphql/value-to-ast';
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether the @defaultValue directive on the field and on the basleine field match
@@ -24,7 +23,7 @@ export function checkDefaultValue(
                 'DEFAULT_VALUE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not have a default value${getRequiredBySuffix(baselineField)}.`,
+                }" should not have a default value.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.defaultValueAstNode },
             ),
@@ -47,9 +46,7 @@ export function checkDefaultValue(
                 'DEFAULT_VALUE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with ${expectedDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be decorated with ${expectedDeclaration}.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.defaultValueAstNode },
             ),
@@ -62,9 +59,7 @@ export function checkDefaultValue(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'DEFAULT_VALUE',
-                `Default value should be ${expectedDefaultValue}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                `Default value should be ${expectedDefaultValue}.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.defaultValueAstNode },
             ),

--- a/src/model/compatibility-check/check-enum-type.ts
+++ b/src/model/compatibility-check/check-enum-type.ts
@@ -1,6 +1,5 @@
 import { EnumType } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 export function checkEnumType(
     typeToCheck: EnumType,
@@ -10,12 +9,12 @@ export function checkEnumType(
     for (const baselineValue of baselineType.values) {
         const matchingValue = typeToCheck.values.find((v) => v.value === baselineValue.value);
         if (!matchingValue) {
+            // No requiredBySuffix here because currently, it's not possible to assign individual
+            // enum values to modules (the full enum is included in a module or it is not)
             context.addMessage(
                 ValidationMessage.suppressableCompatibilityIssue(
                     'MISSING_ENUM_VALUE',
-                    `Enum value "${baselineValue.value}" is missing${getRequiredBySuffix(
-                        baselineType,
-                    )}.`,
+                    `Enum value "${baselineValue.value}" is missing.`,
                     typeToCheck.astNode,
                     { location: typeToCheck.nameASTNode },
                 ),

--- a/src/model/compatibility-check/check-field-type.ts
+++ b/src/model/compatibility-check/check-field-type.ts
@@ -3,7 +3,6 @@ import { Field } from '../implementation/field';
 import { QuickFix } from '../validation';
 import { ValidationMessage } from '../validation/message';
 import { ValidationContext } from '../validation/validation-context';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether the field has the same type as the baseline field, including whether or not they are lists
@@ -35,7 +34,7 @@ export function checkFieldType(
                 'FIELD_TYPE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" needs to be of type "${expectedType}"${getRequiredBySuffix(baselineField)}.`,
+                }" needs to be of type "${expectedType}".`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.astNode?.type,
@@ -49,7 +48,7 @@ export function checkFieldType(
                 'FIELD_TYPE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be a list${getRequiredBySuffix(baselineField)}.`,
+                }" should not be a list.`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.astNode?.type,
@@ -63,7 +62,7 @@ export function checkFieldType(
                 'FIELD_TYPE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" needs to be a list${getRequiredBySuffix(baselineField)}.`,
+                }" needs to be a list.`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.astNode?.type,

--- a/src/model/compatibility-check/check-flex-search-on-field.ts
+++ b/src/model/compatibility-check/check-flex-search-on-field.ts
@@ -1,15 +1,10 @@
-import { Field, RootEntityType } from '../implementation';
+import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
-import { ArgumentNode, Kind, ListValueNode, ObjectValueNode, print } from 'graphql';
-import { OrderDirection } from '../implementation/order';
 import {
     FLEX_SEARCH_FULLTEXT_INDEXED_DIRECTIVE,
     FLEX_SEARCH_INCLUDED_IN_SEARCH_ARGUMENT,
     FLEX_SEARCH_INDEXED_DIRECTIVE,
-    FLEX_SEARCH_ORDER_ARGUMENT,
 } from '../../schema/constants';
-import { FlexSearchPrimarySortClause } from '../implementation/flex-search';
 
 export function checkFlexSearchOnField(
     fieldToCheck: Field,
@@ -33,9 +28,7 @@ export function checkRegularDirective(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'FLEX_SEARCH',
-                `Field "${
-                    baselineField.name
-                }" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}${getRequiredBySuffix(baselineField)}.`,
+                `Field "${baselineField.name}" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -48,7 +41,7 @@ export function checkRegularDirective(
                 'FLEX_SEARCH_SEARCH',
                 `Field "${
                     baselineField.name
-                }" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}(${FLEX_SEARCH_INCLUDED_IN_SEARCH_ARGUMENT}: true)${getRequiredBySuffix(baselineField)}.`,
+                }" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}(${FLEX_SEARCH_INCLUDED_IN_SEARCH_ARGUMENT}: true).`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.isFlexSearchIndexedAstNode },
             ),
@@ -71,7 +64,7 @@ export function checkFulltextDirective(
                 'FLEX_SEARCH',
                 `Field "${
                     baselineField.name
-                }" should enable @${FLEX_SEARCH_FULLTEXT_INDEXED_DIRECTIVE}${getRequiredBySuffix(baselineField)}.`,
+                }" should enable @${FLEX_SEARCH_FULLTEXT_INDEXED_DIRECTIVE}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -84,7 +77,7 @@ export function checkFulltextDirective(
                 'FLEX_SEARCH_SEARCH',
                 `Field "${
                     baselineField.name
-                }" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}(${FLEX_SEARCH_INCLUDED_IN_SEARCH_ARGUMENT}: true)${getRequiredBySuffix(baselineField)}.`,
+                }" should enable @${FLEX_SEARCH_INDEXED_DIRECTIVE}(${FLEX_SEARCH_INCLUDED_IN_SEARCH_ARGUMENT}: true).`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.isFlexSearchFullTextIndexedAstNode },
             ),

--- a/src/model/compatibility-check/check-flex-search-on-type.ts
+++ b/src/model/compatibility-check/check-flex-search-on-type.ts
@@ -1,6 +1,5 @@
 import { RootEntityType } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 import { ArgumentNode, Kind, ListValueNode, ObjectValueNode, print } from 'graphql';
 import { OrderDirection } from '../implementation/order';
 import { FLEX_SEARCH_ORDER_ARGUMENT } from '../../schema/constants';
@@ -15,9 +14,7 @@ export function checkFlexSearchOnType(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'FLEX_SEARCH',
-                `Type "${
-                    baselineType.name
-                }" needs to be enable flexSearch${getRequiredBySuffix(baselineType)}.`,
+                `Type "${baselineType.name}" needs to be enable flexSearch.`,
                 typeToCheck.astNode,
                 { location: typeToCheck.isFlexSearchIndexedAstNode ?? typeToCheck.nameASTNode },
             ),
@@ -57,7 +54,7 @@ function checkPrimarySort(
                 'FLEX_SEARCH_ORDER',
                 `Type "${
                     baselineType.name
-                }" should not specify a custom ${FLEX_SEARCH_ORDER_ARGUMENT}${getRequiredBySuffix(baselineType)}.`,
+                }" should not specify a custom ${FLEX_SEARCH_ORDER_ARGUMENT}.`,
                 typeToCheck.astNode,
                 { location: typeToCheck.flexSearchPrimarySortAstNode ?? typeToCheck.nameASTNode },
             ),
@@ -80,9 +77,7 @@ function checkPrimarySort(
     context.addMessage(
         ValidationMessage.suppressableCompatibilityIssue(
             'FLEX_SEARCH_ORDER',
-            `Type "${
-                baselineType.name
-            }" should specify ${print(expectedArgumentNode)}${getRequiredBySuffix(baselineType)}.`,
+            `Type "${baselineType.name}" should specify ${print(expectedArgumentNode)}.`,
             typeToCheck.astNode,
             {
                 // if the user specified the argument, report it there (suggesting to change it)

--- a/src/model/compatibility-check/check-key-field.ts
+++ b/src/model/compatibility-check/check-key-field.ts
@@ -2,7 +2,6 @@ import { ID_FIELD } from '../../schema/constants';
 import { Field } from '../implementation/field';
 import { ValidationMessage } from '../validation/message';
 import { ValidationContext } from '../validation/validation-context';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * If the baseline field is annotated with @key, checks whether the field is annotated with @key, too
@@ -26,9 +25,7 @@ export function checkKeyField(
             // code for "id", wait until we have a way to suppress missing fields in general.
             context.addMessage(
                 ValidationMessage.nonSuppressableCompatibilityIssue(
-                    `Field "id: ID @key" needs to be specified${getRequiredBySuffix(
-                        baselineField,
-                    )}.`,
+                    `Field "id: ID @key" needs to be specified.`,
                     fieldToCheck.declaringType.nameASTNode ?? fieldToCheck.declaringType.astNode,
                 ),
             );
@@ -38,7 +35,7 @@ export function checkKeyField(
                     'KEY_FIELD',
                     `Field "${baselineField.declaringType.name}.${
                         baselineField.name
-                    }" needs to be decorated with @key${getRequiredBySuffix(baselineField)}.`,
+                    }" needs to be decorated with @key.`,
                     fieldToCheck.astNode,
                 ),
             );

--- a/src/model/compatibility-check/check-model.ts
+++ b/src/model/compatibility-check/check-model.ts
@@ -1,11 +1,11 @@
-import { Kind, print, TypeDefinitionNode } from 'graphql';
+import { Kind, TypeDefinitionNode } from 'graphql';
 import { MODULES_DIRECTIVE } from '../../schema/constants';
 import { AppendChange, ChangeSet } from '../change-set/change-set';
 import { Model } from '../implementation';
 import { QuickFix, ValidationContext, ValidationMessage, ValidationResult } from '../validation';
 import { checkType } from './check-type';
-import { getRequiredBySuffix } from './describe-module-specification';
 import { prettyPrint } from '../../graphql/pretty-print';
+import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether a model (modelToCheck) can be used in a place where another model (baselineModel) is expected.

--- a/src/model/compatibility-check/check-reference.ts
+++ b/src/model/compatibility-check/check-reference.ts
@@ -1,6 +1,5 @@
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether the @reference directives on the field and on the baseline field match
@@ -16,7 +15,7 @@ export function checkReference(
                 'REFERENCE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be a reference${getRequiredBySuffix(baselineField)}.`,
+                }" should not be a reference.`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.referenceAstNode,
@@ -46,9 +45,7 @@ export function checkReference(
                 'REFERENCE',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with ${expectedReferenceDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be decorated with ${expectedReferenceDeclaration}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -64,7 +61,7 @@ export function checkReference(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'REFERENCE',
-                `Reference should not declare a keyField${getRequiredBySuffix(baselineField)}.`,
+                `Reference should not declare a keyField.`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.referenceAstNode,
@@ -86,9 +83,7 @@ export function checkReference(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'REFERENCE',
-                `Reference should declare ${expectedKeyFieldDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                `Reference should declare ${expectedKeyFieldDeclaration}.`,
                 fieldToCheck.astNode,
                 {
                     location: fieldToCheck.referenceAstNode,

--- a/src/model/compatibility-check/check-relation.ts
+++ b/src/model/compatibility-check/check-relation.ts
@@ -1,7 +1,6 @@
 import { RelationDeleteAction } from '../config/field';
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether the @relation directive on the field and on the baseline field match
@@ -18,7 +17,7 @@ export function checkRelation(
                 'RELATION',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be a relation${getRequiredBySuffix(baselineField)}.`,
+                }" should not be a relation.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.relationAstNode },
             ),
@@ -52,9 +51,7 @@ export function checkRelation(
                 'RELATION',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with ${expectedRelationDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be decorated with ${expectedRelationDeclaration}.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -68,9 +65,7 @@ export function checkRelation(
                 'RELATION',
                 `Relation "${
                     baselineField.name
-                }" should be a forward relation, not an inverse relation${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be a forward relation, not an inverse relation.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.inverseOfAstNode },
             ),
@@ -87,9 +82,7 @@ export function checkRelation(
                 'RELATION',
                 `Relation "${
                     baselineField.name
-                }" should be an inverse relation with ${expectedInverseOfDeclaration}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                }" should be an inverse relation with ${expectedInverseOfDeclaration}.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.inverseOfAstNode ?? fieldToCheck.relationAstNode },
             ),
@@ -105,9 +98,7 @@ export function checkRelation(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'RELATION',
-                `Relation "${baselineField.name}" should ${hint}${getRequiredBySuffix(
-                    baselineField,
-                )}.`,
+                `Relation "${baselineField.name}" should ${hint}.`,
                 fieldToCheck.astNode,
                 {
                     location:

--- a/src/model/compatibility-check/check-root-and-parent-directives.ts
+++ b/src/model/compatibility-check/check-root-and-parent-directives.ts
@@ -1,6 +1,5 @@
 import { Field } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 /**
  * Checks whether @root and @parent are specified exactly when they are specified in the baseline field
@@ -16,7 +15,7 @@ export function checkRootAndParentDirectives(
                 'ROOT_FIELD',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be decorated with @root${getRequiredBySuffix(baselineField)}.`,
+                }" should not be decorated with @root.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.rootDirectiveAstNode },
             ),
@@ -29,7 +28,7 @@ export function checkRootAndParentDirectives(
                 'ROOT_FIELD',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with @root${getRequiredBySuffix(baselineField)}.`,
+                }" should be decorated with @root.`,
                 fieldToCheck.astNode,
             ),
         );
@@ -41,7 +40,7 @@ export function checkRootAndParentDirectives(
                 'PARENT_FIELD',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should not be decorated with @parent${getRequiredBySuffix(baselineField)}.`,
+                }" should not be decorated with @parent.`,
                 fieldToCheck.astNode,
                 { location: fieldToCheck.parentDirectiveAstNode },
             ),
@@ -54,7 +53,7 @@ export function checkRootAndParentDirectives(
                 'PARENT_FIELD',
                 `Field "${baselineField.declaringType.name}.${
                     baselineField.name
-                }" should be decorated with @parent${getRequiredBySuffix(baselineField)}.`,
+                }" should be decorated with @parent.`,
                 fieldToCheck.astNode,
             ),
         );

--- a/src/model/compatibility-check/check-root-entity-type.ts
+++ b/src/model/compatibility-check/check-root-entity-type.ts
@@ -1,7 +1,5 @@
-import { ObjectType, RootEntityType } from '../implementation';
-import { ValidationContext, ValidationMessage } from '../validation';
-import { checkField } from './check-field';
-import { getRequiredBySuffix } from './describe-module-specification';
+import { RootEntityType } from '../implementation';
+import { ValidationContext } from '../validation';
 import { checkBusinessObject } from './check-business-object';
 import { checkTtl } from './check-ttl';
 import { checkFlexSearchOnType } from './check-flex-search-on-type';

--- a/src/model/compatibility-check/check-ttl.ts
+++ b/src/model/compatibility-check/check-ttl.ts
@@ -1,7 +1,5 @@
-import { ObjectType, RootEntityType } from '../implementation';
+import { RootEntityType } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
-import { checkField } from './check-field';
-import { getRequiredBySuffix } from './describe-module-specification';
 
 export function checkTtl(
     typeToCheck: RootEntityType,
@@ -12,7 +10,7 @@ export function checkTtl(
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'TTL',
-                `There should be a timeToLive configuration for type "${baselineType.name}"${getRequiredBySuffix(baselineType)}.`,
+                `There should be a timeToLive configuration for type "${baselineType.name}".`,
                 typeToCheck.astNode,
                 { location: typeToCheck.nameASTNode },
             ),

--- a/src/model/compatibility-check/check-type.ts
+++ b/src/model/compatibility-check/check-type.ts
@@ -2,7 +2,6 @@ import { Type } from '../implementation';
 import { ValidationContext, ValidationMessage } from '../validation';
 import { checkEnumType } from './check-enum-type';
 import { checkObjectType } from './check-object-type';
-import { getRequiredBySuffix } from './describe-module-specification';
 import { describeTypeKind } from './utils';
 
 export function checkType(typeToCheck: Type, baselineType: Type, context: ValidationContext) {
@@ -10,9 +9,7 @@ export function checkType(typeToCheck: Type, baselineType: Type, context: Valida
         context.addMessage(
             ValidationMessage.suppressableCompatibilityIssue(
                 'TYPE_KIND',
-                `Type "${baselineType.name}" needs to be ${describeTypeKind(
-                    baselineType.kind,
-                )}${getRequiredBySuffix(baselineType)}.`,
+                `Type "${baselineType.name}" needs to be ${describeTypeKind(baselineType.kind)}.`,
 
                 typeToCheck.astNode,
                 { location: typeToCheck.nameASTNode },


### PR DESCRIPTION
As soon as a module includes a field or type, it includes all of its specialities. Checks like whether the type match are independent of the module selection. For this reason, it is noisy and confusing to include the list of modules in the messages.