### PR TITLE
feat: guarantee a well-defined order for all flexSearch queries

### DIFF
--- a/src/model/implementation/root-entity-type.ts
+++ b/src/model/implementation/root-entity-type.ts
@@ -179,6 +179,8 @@ export class RootEntityType extends ObjectTypeBase {
     @memorize()
     get discriminatorField(): Field {
         // later, we can return @key here when it exists and is required
+        // however, consider: this is used everywhere in primarySort, so changing it would cause
+        // migrations to re-create all flexsearch views
         return this.getFieldOrThrow(ID_FIELD);
     }
 

--- a/src/schema-generation/flex-search-generator.ts
+++ b/src/schema-generation/flex-search-generator.ts
@@ -222,8 +222,10 @@ export class FlexSearchGenerator {
             ...schemaField,
             transform: (sourceNode, args, context) => {
                 const assertionVariable = new VariableQueryNode();
-                // If a filter or an order_by is specified, a pre-execution query node is added that throws a TOO_MANY_OBJECTS_ERROR if the amount of objects the filter or order_by is
-                // used on is to large
+                // If a filter or an order_by is specified, a pre-execution query node is added
+                // that throws a TOO_MANY_OBJECTS_ERROR if the amount of objects returned by the
+                // flexSearchFilter is too large. This prevents performance issues with
+                // in-memory filtering and sorting.
                 const filterArg = args[POST_FILTER_ARG] || args[FILTER_ARG];
                 if (
                     (filterArg && Object.keys(filterArg).length > 0) ||

--- a/src/schema-generation/output-type-generator.ts
+++ b/src/schema-generation/output-type-generator.ts
@@ -36,7 +36,10 @@ import {
     QueryNodeOutputType,
 } from './query-node-object-type';
 import { RootFieldHelper } from './root-field-helper';
-import { orderArgMatchesPrimarySort } from './utils/flex-search-utils';
+import {
+    getSortClausesForPrimarySort,
+    orderArgMatchesPrimarySort,
+} from './utils/flex-search-utils';
 import { getOrderByValues } from './utils/pagination';
 
 export class OutputTypeGenerator {
@@ -159,13 +162,7 @@ export class OutputTypeGenerator {
                 objectType.flexSearchPrimarySort,
             )
         ) {
-            // this would be cleaner if the primary sort was actually parsed into a ModelComponent (see e.g. the Index and IndexField classes)
-            orderByValues = objectType.flexSearchPrimarySort.map((clause) =>
-                orderByType.getValueOrThrow(
-                    clause.field.path.replace('.', '_') +
-                        (clause.direction === OrderDirection.ASCENDING ? '_ASC' : '_DESC'),
-                ),
-            );
+            orderByValues = getSortClausesForPrimarySort(objectType, orderByType);
         } else {
             orderByValues = getOrderByValues(listFieldRequest.args, orderByType, {
                 isAbsoluteOrderRequired: true,

--- a/src/schema-generation/utils/flex-search-utils.ts
+++ b/src/schema-generation/utils/flex-search-utils.ts
@@ -52,7 +52,7 @@ export function getSortClausesForPrimarySort(
     // this would be cleaner if the primary sort was actually parsed into a ModelComponent (see e.g. the Index and IndexField classes)
     return objectType.flexSearchPrimarySort.map((clause) =>
         orderByType.getValueOrThrow(
-            clause.field.path.replace('.', '_') +
+            clause.field.path.replaceAll('.', '_') +
                 (clause.direction === OrderDirection.ASCENDING ? '_ASC' : '_DESC'),
         ),
     );


### PR DESCRIPTION
A flexSearch query without orderBy will now use the primarySort (flexSearchOrder) as order. If no flexSearchOrder is configured, this defaults to createdAt_DESC, id_DESC. If flexSearchOrder is configured, createdAt_DESC, id_DESC will always be appended to make order deterministic.

A flexSearch query with an explicit orderBy that contradicts with the primarySort (so primarySort cannot be used) will also use an absolute order now.

The performance effect should be relatively minor because using primary sort is very efficient.