### PR TITLE
refactor: fix that strings starting with a digit were considered a va…

### DIFF
--- a/src/database/arangodb/aql.ts
+++ b/src/database/arangodb/aql.ts
@@ -412,7 +412,7 @@ export namespace aql {
      * Caution: should only use in .identifier() and NOT .code() because it does not account for keywords
      */
     export function isSafeIdentifier(str: string) {
-        return typeof str == 'string' && str.match(/^[a-zA-Z0-9_]+$/);
+        return typeof str == 'string' && str.match(/^[a-zA-Z][a-zA-Z0-9_]*$/);
     }
 }
 


### PR DESCRIPTION
…lid AQL identifier

This should not have an effect we only used bare identifiers to access properties, and properties are either built-in names or graphql field names which cannot start with a digit.